### PR TITLE
Add option to decrement respawn time if pet is stored.

### DIFF
--- a/modules/API/src/main/java/de/Keyle/MyPet/api/Configuration.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/Configuration.java
@@ -96,6 +96,7 @@ public class Configuration {
     public static class Respawn {
 
         public static boolean DISABLE_AUTO_RESPAWN = false;
+        public static boolean DECREMENT_TIME_IF_PET_STORED = false;
         public static int TIME_FACTOR = 5;
         public static int TIME_PLAYER_FACTOR = 5;
         public static int TIME_FIXED = 0;

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/util/ConfigurationLoader.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/util/ConfigurationLoader.java
@@ -102,6 +102,7 @@ public class ConfigurationLoader {
         config.addDefault("MyPet.Repository.MongoDB.Port", Repository.MongoDB.PORT);
 
         config.addDefault("MyPet.Respawn.Time.Disabled", Respawn.DISABLE_AUTO_RESPAWN);
+        config.addDefault("MyPet.Respawn.Time.Decrement-If-Pet-Stored", Respawn.DECREMENT_TIME_IF_PET_STORED);
         config.addDefault("MyPet.Respawn.Time.Default.Factor", Respawn.TIME_FACTOR);
         config.addDefault("MyPet.Respawn.Time.Player.Factor", Respawn.TIME_PLAYER_FACTOR);
         config.addDefault("MyPet.Respawn.Time.Default.Fixed", Respawn.TIME_FIXED);
@@ -328,6 +329,7 @@ public class ConfigurationLoader {
         Skilltree.SWITCH_FEE_PERCENT = config.getInt("MyPet.Skilltree.SwitchFee.Percent", 5);
         Skilltree.SWITCH_FEE_ADMIN = config.getBoolean("MyPet.Skilltree.SwitchFee.Admin", false);
         Respawn.DISABLE_AUTO_RESPAWN = config.getBoolean("MyPet.Respawn.Time.Disabled", false);
+        Respawn.DECREMENT_TIME_IF_PET_STORED = config.getBoolean("MyPet.Respawn.Time.Decrement-If-Pet-Stored", false);
         Respawn.TIME_FACTOR = config.getInt("MyPet.Respawn.Time.Default.Factor", 5);
         Respawn.TIME_PLAYER_FACTOR = config.getInt("MyPet.Respawn.Time.Player.Factor", 5);
         Respawn.TIME_FIXED = config.getInt("MyPet.Respawn.Time.Default.Fixed", 0);


### PR DESCRIPTION
I've setup a configuration where pets can have hours until they respawn to encourage caring about your pet's life, so my players were complaining that they could not use other pets when a pet dies because then the respawn timer for their dead pets would not decrement.

So I added this option to my server

Just thought to share it here in case you want to add it as well.