### PR TITLE
Tame Entity problems - PacketError - Decor

### DIFF
--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/admin/CommandOptionCreate.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/admin/CommandOptionCreate.java
@@ -263,7 +263,7 @@ public class CommandOptionCreate implements CommandOptionTabCompleter {
                 .add("baby")
                 .add("chest")
                 .add("variant:")
-                .add("decor:")
+                //.add("decor:")
                 .get());
 
         petTypeOptionMap.put("tropicalfish", new CommandOptionCreator()

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/util/hooks/ProtocolLibHook.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/util/hooks/ProtocolLibHook.java
@@ -53,7 +53,7 @@ public class ProtocolLibHook implements PluginHook {
     @Override
     public boolean onEnable() {
         try {
-        	if(MyPetApi.getCompatUtil().compareWithMinecraftVersion("1.17") <= 0) {
+        	if(MyPetApi.getCompatUtil().compareWithMinecraftVersion("1.17") < 0) {
         		//Don't enable this in 1.17+ bc of crashes/errors
         		registerEnderDragonInteractionFix();
         	}
@@ -154,6 +154,9 @@ public class ProtocolLibHook implements PluginHook {
                         } catch (RuntimeException ignored) {
                         }
                         if (entity == null) {
+                        	if(MyPetApi.getCompatUtil().compareWithMinecraftVersion("1.17") >= 0) { //1.17+ does not like this.
+                        		return;
+                        	}
                             entity = MyPetApi.getPlatformHelper().getEntity(id, event.getPlayer().getWorld());
                         }
 

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/target/BehaviorAggressiveTarget.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/target/BehaviorAggressiveTarget.java
@@ -20,6 +20,10 @@
 
 package de.Keyle.MyPet.compat.v1_17_R1.entity.ai.target;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.entity.LivingEntity;
@@ -32,6 +36,7 @@ import de.Keyle.MyPet.api.entity.ai.target.TargetPriority;
 import de.Keyle.MyPet.api.skill.skills.Behavior;
 import de.Keyle.MyPet.api.skill.skills.Behavior.BehaviorMode;
 import de.Keyle.MyPet.api.util.Compat;
+import de.Keyle.MyPet.api.util.ReflectionUtil;
 import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.TamableAnimal;
@@ -85,14 +90,19 @@ public class BehaviorAggressiveTarget implements AIGoal {
 						continue;
 					}
 				} else if (entityLiving instanceof TamableAnimal) {
+					Method getOwnerReflect = ReflectionUtil.getMethod(TamableAnimal.class, "getOwner"); //Method: getOwner -> mojang mapping maps that to fx() even tho it still is getOwner.
 					TamableAnimal tameable = (TamableAnimal) entityLiving;
-					if (tameable.isTame() && tameable.getOwner() != null) {
-						Player tameableOwner = (Player) tameable.getOwner().getBukkitEntity();
-						if (myPet.getOwner().equals(tameableOwner)) {
-							continue;
-						} else if (!MyPetApi.getHookHelper().canHurt(myPet.getOwner().getPlayer(), tameableOwner, true)) {
-							continue;
+					try {
+						if (tameable.isTame() && getOwnerReflect.invoke(tameable, null) != null) {
+							Player tameableOwner = (Player) ((net.minecraft.world.entity.player.Player) getOwnerReflect.invoke(tameable, null)).getBukkitEntity();
+							if (myPet.getOwner().equals(tameableOwner)) {
+								continue;
+							} else if (!MyPetApi.getHookHelper().canHurt(myPet.getOwner().getPlayer(), tameableOwner, true)) {
+								continue;
+							}
 						}
+					} catch(IllegalAccessException | InvocationTargetException e) {
+		                e.printStackTrace();
 					}
 				} else if (!MyPetApi.getHookHelper().canHurt(myPet.getOwner().getPlayer(), entityLiving.getBukkitEntity())) {
 					continue;

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/target/HurtByTarget.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/target/HurtByTarget.java
@@ -20,6 +20,9 @@
 
 package de.Keyle.MyPet.compat.v1_17_R1.entity.ai.target;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.entity.LivingEntity;
@@ -30,6 +33,7 @@ import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.ai.AIGoal;
 import de.Keyle.MyPet.api.entity.ai.target.TargetPriority;
 import de.Keyle.MyPet.api.util.Compat;
+import de.Keyle.MyPet.api.util.ReflectionUtil;
 import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.TamableAnimal;
@@ -79,12 +83,17 @@ public class HurtByTarget implements AIGoal {
 				return false;
 			}
 		} else if (target instanceof TamableAnimal) {
+			Method getOwnerReflect = ReflectionUtil.getMethod(TamableAnimal.class, "getOwner"); //Method: getOwner -> mojang mapping maps that to fx() even tho it still is getOwner.
 			TamableAnimal tameable = (TamableAnimal) target;
-			if (tameable.isTame() && tameable.getOwner() != null) {
-				Player tameableOwner = (Player) tameable.getOwner().getBukkitEntity();
-				if (myPet.getOwner().equals(tameableOwner)) {
-					return false;
+			try {
+				if (tameable.isTame() && getOwnerReflect.invoke(tameable, null) != null) {
+					Player tameableOwner = (Player) ((net.minecraft.world.entity.player.Player) getOwnerReflect.invoke(tameable, null)).getBukkitEntity();
+					if (myPet.getOwner().equals(tameableOwner)) {
+						return false;
+					}
 				}
+			} catch(IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
 			}
 		}
 		return MyPetApi.getHookHelper().canHurt(myPet.getOwner().getPlayer(), target.getBukkitEntity());

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/target/OwnerHurtByTarget.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/target/OwnerHurtByTarget.java
@@ -20,6 +20,9 @@
 
 package de.Keyle.MyPet.compat.v1_17_R1.entity.ai.target;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.entity.LivingEntity;
@@ -32,6 +35,7 @@ import de.Keyle.MyPet.api.entity.ai.target.TargetPriority;
 import de.Keyle.MyPet.api.skill.skills.Behavior;
 import de.Keyle.MyPet.api.skill.skills.Behavior.BehaviorMode;
 import de.Keyle.MyPet.api.util.Compat;
+import de.Keyle.MyPet.api.util.ReflectionUtil;
 import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.TamableAnimal;
@@ -86,12 +90,17 @@ public class OwnerHurtByTarget implements AIGoal {
 				return false;
 			}
 		} else if (lastDamager instanceof TamableAnimal) {
+			Method getOwnerReflect = ReflectionUtil.getMethod(TamableAnimal.class, "getOwner"); //Method: getOwner -> mojang mapping maps that to fx() even tho it still is getOwner.
 			TamableAnimal tameable = (TamableAnimal) lastDamager;
-			if (tameable.isTame() && tameable.getOwner() != null) {
-				Player tameableOwner = (Player) tameable.getOwner().getBukkitEntity();
-				if (myPet.getOwner().equals(tameableOwner)) {
-					return false;
+			try {
+				if (tameable.isTame() && getOwnerReflect.invoke(tameable, null) != null) {
+					Player tameableOwner = (Player) ((net.minecraft.world.entity.player.Player) getOwnerReflect.invoke(tameable, null)).getBukkitEntity();
+					if (myPet.getOwner().equals(tameableOwner)) {
+						return false;
+					}
 				}
+			} catch(IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
 			}
 		}
 		if (!MyPetApi.getHookHelper().canHurt(myPet.getOwner().getPlayer(), lastDamager.getBukkitEntity())) {


### PR DESCRIPTION
Fixed:
- There should be no more packet-errors
- Fixed a bug where tame entities near aggressive entities (or similar) would cause errors

Tweaked:
- Removed decor command option for trader_llama