### PR TITLE
Swimming (1.17), Fixes and Riding-Item

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and Deploy to GitHub
         run: mvn --batch-mode deploy -DGIT_COMMIT=${{ github.sha }} -DBUILD_NUMBER=${{ env.BUILD_NUMBER }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
 
       - name: Get jar file name
         run: |

--- a/modules/API/src/main/java/de/Keyle/MyPet/api/entity/MyPet.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/entity/MyPet.java
@@ -20,8 +20,10 @@
 
 package de.Keyle.MyPet.api.entity;
 
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.skill.MyPetExperience;
 import de.Keyle.MyPet.api.skill.Skills;
+import de.Keyle.MyPet.api.skill.skilltree.Skilltree;
 import de.Keyle.MyPet.api.util.Scheduler;
 import org.bukkit.Location;
 
@@ -67,4 +69,6 @@ public interface MyPet extends StoredMyPet, Scheduler {
     boolean hasTarget();
 
     void decreaseSaturation(double value);
+    
+    boolean setSkilltree(Skilltree skilltree, MyPetSelectSkilltreeEvent.Source source);
 }

--- a/modules/API/src/main/java/de/Keyle/MyPet/api/entity/StoredMyPet.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/entity/StoredMyPet.java
@@ -20,6 +20,7 @@
 
 package de.Keyle.MyPet.api.entity;
 
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.player.MyPetPlayer;
 import de.Keyle.MyPet.api.skill.skilltree.Skilltree;
 import de.keyle.knbt.TagCompound;

--- a/modules/API/src/main/java/de/Keyle/MyPet/api/entity/ai/navigation/AbstractNavigation.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/entity/ai/navigation/AbstractNavigation.java
@@ -21,6 +21,7 @@
 package de.Keyle.MyPet.api.entity.ai.navigation;
 
 import de.Keyle.MyPet.api.entity.MyPetMinecraftEntity;
+
 import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 

--- a/modules/API/src/main/java/de/Keyle/MyPet/api/event/MyPetSelectSkilltreeEvent.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/event/MyPetSelectSkilltreeEvent.java
@@ -20,36 +20,44 @@
 
 package de.Keyle.MyPet.api.event;
 
-import de.Keyle.MyPet.api.entity.StoredMyPet;
-import de.Keyle.MyPet.api.player.MyPetPlayer;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class MyPetCreateEvent extends Event {
-    protected static final HandlerList handlers = new HandlerList();
+import de.Keyle.MyPet.api.entity.StoredMyPet;
+import de.Keyle.MyPet.api.player.MyPetPlayer;
+import de.Keyle.MyPet.api.skill.skilltree.Skilltree;
 
+public class MyPetSelectSkilltreeEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    protected final StoredMyPet myPet;
+    protected final Skilltree skilltree;
+    private final Source source;
+    
     public enum Source {
-        Leash, AdminCommand, PetShop, Other
+        Auto, PlayerCommand, AdminCommand, AdminCreation, BossShopPro, Shop, Other
     }
 
-    private final StoredMyPet myPet;
-    private final Source source;
-
-    public MyPetCreateEvent(StoredMyPet myPet, Source source) {
+    public MyPetSelectSkilltreeEvent(StoredMyPet myPet, Skilltree skilltree, Source source) {
         this.myPet = myPet;
+        this.skilltree = skilltree;
         this.source = source;
     }
-
+    
     public Source getSource() {
         return source;
     }
 
-    public MyPetPlayer getOwner() {
-        return myPet.getOwner();
-    }
-
     public StoredMyPet getMyPet() {
         return myPet;
+    }
+
+    public Skilltree getSkilltree() {
+        return skilltree;
+    }
+
+    public MyPetPlayer getOwner() {
+        return myPet.getOwner();
     }
 
     public HandlerList getHandlers() {

--- a/modules/API/src/main/java/de/Keyle/MyPet/api/util/ConfigItem.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/util/ConfigItem.java
@@ -63,6 +63,9 @@ public abstract class ConfigItem {
     }
 
     public static ConfigItem createConfigItem(String data) {
+    	if(data.equalsIgnoreCase("none")) {	//For enabling non itembound interaction (riding etc)
+    		return null;
+    	}
         return MyPetApi.getCompatUtil().getComapatInstance(ConfigItem.class, "util", "ConfigItem", data);
     }
 

--- a/modules/API/src/main/java/de/Keyle/MyPet/api/util/chat/parts/ItemTooltip.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/util/chat/parts/ItemTooltip.java
@@ -143,11 +143,19 @@ public class ItemTooltip {
                     if (i > 0) {
                         jsonString += ",";
                     }
+                    if (MyPetApi.getCompatUtil().isCompatible("1.13")) {
+                        jsonString += "\"{\\\"text\\\":";
+                    }
                     if (minorVersion == 7 && lore.get(i).contains(":")) {
                         jsonString += "a:";
                     }
-                    jsonString += "\"" + lore.get(i).replaceAll("\"", "\\\\\"").replaceAll("\'", "\\\'") + "\"";
-
+                    if (MyPetApi.getCompatUtil().isCompatible("1.13")) {
+                    	jsonString += "\\\"" + lore.get(i).replaceAll("\"", "\\\\\"").replaceAll("\'", "\\\'") + "\\\"";
+                        jsonString += "}";
+                    } else {
+                        jsonString += "\"" + lore.get(i).replaceAll("\"", "\\\\\"").replaceAll("\'", "\\\'") + "\"";
+                    }
+                    jsonString += "\"";
                 }
                 jsonString += "]";
             }

--- a/modules/MyPet/pom.xml
+++ b/modules/MyPet/pom.xml
@@ -49,7 +49,7 @@
     <distributionManagement>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/scomans/MyPet</url>
+            <url>https://maven.pkg.github.com/MyPetORG/MyPet</url>
         </repository>
     </distributionManagement>
 

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandChooseSkilltree.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandChooseSkilltree.java
@@ -26,6 +26,7 @@ import de.Keyle.MyPet.api.Util;
 import de.Keyle.MyPet.api.WorldGroup;
 import de.Keyle.MyPet.api.commands.CommandTabCompleter;
 import de.Keyle.MyPet.api.entity.MyPet;
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.gui.IconMenu;
 import de.Keyle.MyPet.api.gui.IconMenuItem;
 import de.Keyle.MyPet.api.player.MyPetPlayer;
@@ -80,7 +81,7 @@ public class CommandChooseSkilltree implements CommandTabCompleter {
                                 int requiredLevel = skilltree.getRequiredLevel();
                                 if (requiredLevel > 1 && myPet.getExperience().getLevel() < requiredLevel) {
                                     myPet.getOwner().sendMessage(Util.formatText(Translation.getString("Message.Skilltree.RequiresLevel.Message", player), myPet.getPetName(), requiredLevel));
-                                } else if (myPet.setSkilltree(skilltree)) {
+                                } else if (myPet.setSkilltree(skilltree, MyPetSelectSkilltreeEvent.Source.PlayerCommand)) {
                                     sender.sendMessage(Util.formatText(Translation.getString("Message.Skilltree.SwitchedTo", player), Colorizer.setColors(skilltree.getDisplayName())));
                                     if (!myPet.getOwner().isMyPetAdmin() || Configuration.Skilltree.SWITCH_FEE_ADMIN) {
                                         double switchPenalty = Configuration.Skilltree.SWITCH_FEE_FIXED;
@@ -134,7 +135,7 @@ public class CommandChooseSkilltree implements CommandTabCompleter {
                                 int requiredLevel = selecedSkilltree.getRequiredLevel();
                                 if (requiredLevel > 1 && myPet.getExperience().getLevel() < requiredLevel) {
                                     myPet.getOwner().sendMessage(Util.formatText(Translation.getString("Message.Skilltree.RequiresLevel.Message", myPetOwner), myPet.getPetName(), requiredLevel));
-                                } else if (myPet.setSkilltree(selecedSkilltree)) {
+                                } else if (myPet.setSkilltree(selecedSkilltree, MyPetSelectSkilltreeEvent.Source.PlayerCommand)) {
                                     myPet.getOwner().sendMessage(Util.formatText(Translation.getString("Message.Skilltree.SwitchedTo", myPetOwner), Colorizer.setColors(selecedSkilltree.getDisplayName())));
                                     if (!myPet.getOwner().isMyPetAdmin() || Configuration.Skilltree.SWITCH_FEE_ADMIN) {
                                         double switchPenalty = Configuration.Skilltree.SWITCH_FEE_FIXED;

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandRelease.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandRelease.java
@@ -128,7 +128,7 @@ public class CommandRelease implements CommandTabCompleter {
                     lore.add(RESET + Translation.getString("Name.Exp", petOwner) + ": " + GOLD + String.format("%1.2f", myPet.getExp()));
                     lore.add(RESET + Translation.getString("Name.Type", petOwner) + ": " + GOLD + Translation.getString("Name." + myPet.getPetType().name(), petOwner));
                     lore.add(RESET + Translation.getString("Name.Skilltree", petOwner) + ": " + GOLD + (myPet.getSkilltree() != null ? Colorizer.setColors(myPet.getSkilltree().getDisplayName()) : "-"));
-
+                    
                     message.then(myPet.getPetName())
                             .color(ChatColor.AQUA)
                             .command("/petrelease " + ChatColor.stripColor(myPet.getPetName()))

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/admin/CommandOptionCreate.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/admin/CommandOptionCreate.java
@@ -29,6 +29,7 @@ import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.MyPetType;
 import de.Keyle.MyPet.api.event.MyPetCreateEvent;
 import de.Keyle.MyPet.api.event.MyPetSaveEvent;
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.exceptions.MyPetTypeNotFoundException;
 import de.Keyle.MyPet.api.player.MyPetPlayer;
 import de.Keyle.MyPet.api.repository.RepositoryCallback;
@@ -455,7 +456,7 @@ public class CommandOptionCreate implements CommandOptionTabCompleter {
                 String skilltreeName = arg.replace("skilltree:", "");
                 Skilltree skilltree = MyPetApi.getSkilltreeManager().getSkilltree(skilltreeName);
                 if (skilltree != null) {
-                    inactiveMyPet.setSkilltree(skilltree);
+                    inactiveMyPet.setSkilltree(skilltree, MyPetSelectSkilltreeEvent.Source.AdminCreation);
                 }
             } else if (arg.startsWith("name:")) {
                 String name = arg.replace("name:", "");

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/admin/CommandOptionSkilltree.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/admin/CommandOptionSkilltree.java
@@ -24,6 +24,7 @@ import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.Util;
 import de.Keyle.MyPet.api.commands.CommandOptionTabCompleter;
 import de.Keyle.MyPet.api.entity.MyPet;
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.skill.skilltree.Skilltree;
 import de.Keyle.MyPet.api.util.Colorizer;
 import de.Keyle.MyPet.api.util.locale.Translation;
@@ -64,7 +65,7 @@ public class CommandOptionSkilltree implements CommandOptionTabCompleter {
 
         if (MyPetApi.getSkilltreeManager().hasSkilltree(args[1])) {
             Skilltree skilltree = MyPetApi.getSkilltreeManager().getSkilltree(args[1]);
-            if (skilltree.getMobTypes().contains(myPet.getPetType()) && myPet.setSkilltree(skilltree)) {
+            if (skilltree.getMobTypes().contains(myPet.getPetType()) && myPet.setSkilltree(skilltree, MyPetSelectSkilltreeEvent.Source.AdminCommand)) {
                 sender.sendMessage("[" + ChatColor.AQUA + "MyPet" + ChatColor.RESET + "] " + Util.formatText(Translation.getString("Message.Skilltree.SwitchedToFor", lang), petOwner.getName(), Colorizer.setColors(skilltree.getDisplayName())));
             } else {
                 sender.sendMessage("[" + ChatColor.AQUA + "MyPet" + ChatColor.RESET + "] " + Translation.getString("Message.Skilltree.NotSwitched", lang));

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/entity/InactiveMyPet.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/entity/InactiveMyPet.java
@@ -24,6 +24,7 @@ import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.Util;
 import de.Keyle.MyPet.api.entity.MyPetType;
 import de.Keyle.MyPet.api.entity.StoredMyPet;
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.player.MyPetPlayer;
 import de.Keyle.MyPet.api.skill.skilltree.Skill;
 import de.Keyle.MyPet.api.skill.skilltree.Skilltree;
@@ -32,6 +33,8 @@ import de.keyle.knbt.*;
 
 import java.util.Collection;
 import java.util.UUID;
+
+import org.bukkit.Bukkit;
 
 public class InactiveMyPet implements StoredMyPet, NBTStorage {
     private MyPetPlayer petOwner;
@@ -151,6 +154,13 @@ public class InactiveMyPet implements StoredMyPet, NBTStorage {
 
     public boolean setSkilltree(Skilltree skilltree) {
         this.skilltree = skilltree;
+        return true;
+    }
+    
+    public boolean setSkilltree(Skilltree skilltree, MyPetSelectSkilltreeEvent.Source source) {
+        this.skilltree = skilltree;
+        MyPetSelectSkilltreeEvent selectEvent = new MyPetSelectSkilltreeEvent(this, skilltree, source);
+        Bukkit.getServer().getPluginManager().callEvent(selectEvent);
         return true;
     }
 

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/listeners/MyPetEntityListener.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/listeners/MyPetEntityListener.java
@@ -53,6 +53,7 @@ import de.Keyle.MyPet.commands.CommandInfo.PetInfoDisplay;
 import de.Keyle.MyPet.skill.skills.BackpackImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.GameRule;
 import org.bukkit.Material;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
@@ -565,7 +566,7 @@ public class MyPetEntityListener implements Listener {
 
     @SuppressWarnings("RedundantCast")
     private void sendDeathMessage(final EntityDeathEvent event) {
-        if (event.getEntity() instanceof MyPetBukkitEntity) {
+        if (event.getEntity() instanceof MyPetBukkitEntity && event.getEntity().getWorld().getGameRuleValue(GameRule.SHOW_DEATH_MESSAGES)) {
             MyPet myPet = ((MyPetBukkitEntity) event.getEntity()).getMyPet();
             String killer;
             if (event.getEntity().getLastDamageCause() instanceof EntityDamageByEntityEvent) {

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/util/hooks/BossShopProHook.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/util/hooks/BossShopProHook.java
@@ -26,6 +26,7 @@ import de.Keyle.MyPet.api.WorldGroup;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.MyPetType;
 import de.Keyle.MyPet.api.entity.StoredMyPet;
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.exceptions.MyPetTypeNotFoundException;
 import de.Keyle.MyPet.api.player.MyPetPlayer;
 import de.Keyle.MyPet.api.player.Permissions;

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/util/shop/PetShop.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/util/shop/PetShop.java
@@ -26,6 +26,7 @@ import de.Keyle.MyPet.api.Util;
 import de.Keyle.MyPet.api.WorldGroup;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.StoredMyPet;
+import de.Keyle.MyPet.api.event.MyPetCreateEvent;
 import de.Keyle.MyPet.api.exceptions.MyPetTypeNotFoundException;
 import de.Keyle.MyPet.api.gui.IconMenu;
 import de.Keyle.MyPet.api.gui.IconMenuItem;
@@ -146,6 +147,8 @@ public class PetShop {
                                         @Override
                                         public void callback(Boolean value) {
                                             p.sendMessage(Util.formatText(Translation.getString("Message.Shop.Success", player), clonedPet.getPetName(), economyHook.getEconomy().format(pet.getPrice())));
+                                            MyPetCreateEvent createEvent = new MyPetCreateEvent(clonedPet, MyPetCreateEvent.Source.PetShop);
+                                            Bukkit.getServer().getPluginManager().callEvent(createEvent);
                                             if (petOwner.hasMyPet()) {
                                                 p.sendMessage(Util.formatText(Translation.getString("Message.Shop.SuccessStorage", player), clonedPet.getPetName()));
                                             } else {

--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/util/shop/ShopMyPet.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/util/shop/ShopMyPet.java
@@ -23,6 +23,7 @@ package de.Keyle.MyPet.util.shop;
 import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.entity.MyPetType;
 import de.Keyle.MyPet.api.entity.StoredMyPet;
+import de.Keyle.MyPet.api.event.MyPetSelectSkilltreeEvent;
 import de.Keyle.MyPet.api.gui.IconMenuItem;
 import de.Keyle.MyPet.api.player.MyPetPlayer;
 import de.Keyle.MyPet.api.skill.skilltree.Skilltree;
@@ -32,6 +33,8 @@ import de.Keyle.MyPet.api.util.locale.Translation;
 import de.Keyle.MyPet.api.util.service.types.EggIconService;
 import de.Keyle.MyPet.commands.admin.CommandOptionCreate;
 import de.keyle.knbt.TagCompound;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -178,6 +181,8 @@ public class ShopMyPet implements StoredMyPet {
 
     public boolean setSkilltree(Skilltree skilltree) {
         this.skilltree = skilltree;
+        MyPetSelectSkilltreeEvent selectEvent = new MyPetSelectSkilltreeEvent(this, skilltree, MyPetSelectSkilltreeEvent.Source.Shop);
+        Bukkit.getServer().getPluginManager().callEvent(selectEvent);
         return true;
     }
 

--- a/modules/v1_12_R1/src/main/java/de/Keyle/MyPet/compat/v1_12_R1/entity/EntityMyPet.java
+++ b/modules/v1_12_R1/src/main/java/de/Keyle/MyPet/compat/v1_12_R1/entity/EntityMyPet.java
@@ -432,7 +432,7 @@ public abstract class EntityMyPet extends EntityCreature implements IAnimal, MyP
         Player owner = this.getOwner().getPlayer();
 
         if (isMyPet() && myPet.getOwner().equals(entityhuman)) {
-            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
                 if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
                     if (Permissions.hasExtended(owner, "MyPet.extended.ride")) {
                         ((CraftPlayer) owner).getHandle().startRiding(this);

--- a/modules/v1_12_R1/src/main/java/de/Keyle/MyPet/compat/v1_12_R1/entity/ai/movement/Control.java
+++ b/modules/v1_12_R1/src/main/java/de/Keyle/MyPet/compat/v1_12_R1/entity/ai/movement/Control.java
@@ -49,7 +49,7 @@ public class Control implements AIGoal, Scheduler {
 
     @Override
     public boolean shouldStart() {
-        if (!this.myPet.getEntity().get().canMove()) {
+        if (this.myPet.getEntity().isEmpty() || !this.myPet.getEntity().get().canMove()) {
             return false;
         }
         ControlImpl controlSkill = myPet.getSkills().get(ControlImpl.class);

--- a/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/EntityMyPet.java
+++ b/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/EntityMyPet.java
@@ -465,7 +465,7 @@ public abstract class EntityMyPet extends EntityInsentient implements MyPetMinec
         Player owner = this.getOwner().getPlayer();
 
         if (isMyPet() && myPet.getOwner().equals(entityhuman)) {
-            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
                 if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
                     if (Permissions.hasExtended(owner, "MyPet.extended.ride")) {
                         ((CraftPlayer) owner).getHandle().startRiding(this);

--- a/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/ai/movement/Control.java
+++ b/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/ai/movement/Control.java
@@ -50,7 +50,7 @@ public class Control implements AIGoal, Scheduler {
 
     @Override
     public boolean shouldStart() {
-        if (!this.myPet.getEntity().get().canMove()) {
+        if (this.myPet.getEntity().isEmpty() || !this.myPet.getEntity().get().canMove()) {
             return false;
         }
         ControlImpl controlSkill = myPet.getSkills().get(ControlImpl.class);

--- a/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/types/EntityMyOcelot.java
+++ b/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/types/EntityMyOcelot.java
@@ -72,7 +72,7 @@ public class EntityMyOcelot extends EntityMyPet {
                 }
             }
         }
-        return EnumInteractionResult.CONSUME;
+        return EnumInteractionResult.PASS;
     }
 
     @Override

--- a/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/types/EntityMyRavager.java
+++ b/modules/v1_16_R1/src/main/java/de/Keyle/MyPet/compat/v1_16_R1/entity/types/EntityMyRavager.java
@@ -66,7 +66,7 @@ public class EntityMyRavager extends EntityMyPet {
 
     @Override
     public EnumInteractionResult handlePlayerInteraction(EntityHuman entityhuman, EnumHand enumhand, ItemStack itemStack) {
-        if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+        if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
             if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
                 getOwner().sendMessage("Unfortunately, Ravagers can not be ridden (Minecraft limitation)", 5000);
                 return EnumInteractionResult.CONSUME;

--- a/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/EntityMyPet.java
+++ b/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/EntityMyPet.java
@@ -514,7 +514,7 @@ public abstract class EntityMyPet extends EntityInsentient implements MyPetMinec
 		Player owner = this.getOwner().getPlayer();
 
 		if (isMyPet() && myPet.getOwner().equals(entityhuman)) {
-			if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+			if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
 				if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
 					if (Permissions.hasExtended(owner, "MyPet.extended.ride")) {
 						((CraftPlayer) owner).getHandle().startRiding(this);

--- a/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/ai/movement/Control.java
+++ b/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/ai/movement/Control.java
@@ -50,7 +50,7 @@ public class Control implements AIGoal, Scheduler {
 
     @Override
     public boolean shouldStart() {
-        if (!this.myPet.getEntity().get().canMove()) {
+        if (this.myPet.getEntity().isEmpty() || !this.myPet.getEntity().get().canMove()) {
             return false;
         }
         ControlImpl controlSkill = myPet.getSkills().get(ControlImpl.class);

--- a/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/types/EntityMyOcelot.java
+++ b/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/types/EntityMyOcelot.java
@@ -72,7 +72,7 @@ public class EntityMyOcelot extends EntityMyPet {
 				}
 			}
 		}
-		return EnumInteractionResult.CONSUME;
+		return EnumInteractionResult.PASS;
 	}
 
 	@Override

--- a/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/types/EntityMyRavager.java
+++ b/modules/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/types/EntityMyRavager.java
@@ -66,7 +66,7 @@ public class EntityMyRavager extends EntityMyPet {
 
 	@Override
 	public EnumInteractionResult handlePlayerInteraction(EntityHuman entityhuman, EnumHand enumhand, ItemStack itemStack) {
-		if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+		if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
 			if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
 				getOwner().sendMessage("Unfortunately, Ravagers can not be ridden (Minecraft limitation)", 5000);
 				return EnumInteractionResult.CONSUME;

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/PlatformHelper.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/PlatformHelper.java
@@ -186,11 +186,14 @@ public class PlatformHelper extends de.Keyle.MyPet.api.PlatformHelper {
 
     @Override
     public boolean canSpawn(Location loc, MyPetMinecraftEntity entity) {
-        return canSpawn(loc, ((net.minecraft.world.entity.LivingEntity) entity).getBoundingBox());
+        return canSpawn(loc, ((net.minecraft.world.entity.LivingEntity) entity).getBoundingBox(), ((net.minecraft.world.entity.LivingEntity) entity).canBreatheUnderwater());
     }
 
-    public Boolean canSpawn(Location loc, AABB bb) {
+    public Boolean canSpawn(Location loc, AABB bb, boolean canSpawnUnderwater) {
         net.minecraft.world.level.Level mcWorld = ((CraftWorld) loc.getWorld()).getHandle();
+        if(canSpawnUnderwater) {
+        	return getBlockBBsInBB(mcWorld, bb).isEmpty();
+        }
         return getBlockBBsInBB(mcWorld, bb).isEmpty() && !mcWorld.containsAnyLiquid(bb);
     }
 

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/EntityMyAquaticPet.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/EntityMyAquaticPet.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of MyPet
+ *
+ * Copyright © 2011-2020 Keyle
+ * MyPet is licensed under the GNU Lesser General Public License.
+ *
+ * MyPet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyPet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.Keyle.MyPet.compat.v1_17_R1.entity;
+
+import de.Keyle.MyPet.api.entity.EntitySize;
+import de.Keyle.MyPet.api.entity.MyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.ai.navigation.MyPetWaterBoundPathNavigation;
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.MoverType;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+@EntitySize(width = 0.5F, height = 0.3f)
+public abstract class EntityMyAquaticPet extends EntityMyPet {
+
+	public EntityMyAquaticPet(Level world, MyPet myPet) {
+		super(world, myPet);
+	}
+	
+	@Override
+	protected PathNavigation setSpecialNav() {
+		return new MyPetWaterBoundPathNavigation(this, this.level);
+	}
+	
+	@Override
+	public boolean specialFloat() {
+		if(this.isInWater()) {
+	    	return true;
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean canBreatheUnderwater() {
+		return true;
+	}
+	
+	@Override
+	public boolean rideableUnderWater() {
+		return true;
+	}
+	
+	@Override	//Special riding for Underwater
+	protected void ride(double motionSideways, double motionForward, double motionUpwards, float speedModifier) {
+		float speed;
+		
+		if(this.isEyeInFluid(FluidTags.WATER)) {	//No floating, just riding
+			double minY;
+			minY = this.getBoundingBox().minY;
+
+			float friction = 0.91F;
+			if (this.onGround) {
+				friction = this.level.getBlockState(new BlockPos(Mth.floor(this.getX()), Mth.floor(minY) - 1, Mth.floor(this.getZ()))).getBlock().getFriction() * 0.91F;
+			}
+
+			speed = speedModifier * (0.16277136F / (friction * friction * friction));
+			this.moveRelative(speed, new Vec3(motionSideways, motionUpwards, motionForward));
+			
+			double motX = this.getDeltaMovement().x();
+			double motY = this.getDeltaMovement().y();
+			double motZ = this.getDeltaMovement().z();
+
+			Vec3 mot = new Vec3(motX, motY, motZ);
+
+			this.move(MoverType.SELF, mot);
+
+			motY -= 0.08D;
+			motY *= 0.6D;
+
+			motY *= 0.9800000190734863D;
+			motX *= friction;
+			motZ *= friction;
+			this.setDeltaMovement(motX, motY, motZ);
+			
+			this.startRiding(this, false);
+		} else { //Call normal riding when not in water
+			super.ride(motionSideways, motionForward, motionUpwards, speedModifier);
+		}
+	}
+}

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/Control.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/Control.java
@@ -52,7 +52,7 @@ public class Control implements AIGoal, Scheduler {
 
 	@Override
 	public boolean shouldStart() {
-		if (!this.myPet.getEntity().get().canMove()) {
+		if (this.myPet.getEntity().isEmpty() || !this.myPet.getEntity().get().canMove()) {
 			return false;
 		}
 		ControlImpl controlSkill = myPet.getSkills().get(ControlImpl.class);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/Float.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/Float.java
@@ -47,6 +47,9 @@ public class Float implements AIGoal {
 
 	@Override
 	public boolean shouldStart() {
+		if(entityMyPet.floatsInLava()) { //Some entities do that
+			return entityMyPet.isInWater() || entityMyPet.isInLava();
+		}
 		return entityMyPet.isInWater();
 	}
 
@@ -57,6 +60,8 @@ public class Float implements AIGoal {
 
 	@Override
 	public void tick() {
+		if(entityMyPet.specialFloat()) return;	//Check if the entity has some special floating-behaviour for the liquid it is in right now
+		
 		entityMyPet.setDeltaMovement(entityMyPet.getDeltaMovement().add(0, 0.05D, 0));
 
 		if (inLava && lavaCounter-- <= 0) {

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/FollowOwner.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/FollowOwner.java
@@ -29,6 +29,7 @@ import de.Keyle.MyPet.api.entity.ai.AIGoal;
 import de.Keyle.MyPet.api.entity.ai.navigation.AbstractNavigation;
 import de.Keyle.MyPet.api.util.Compat;
 import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.ai.navigation.MyPetWaterBoundPathNavigation;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
@@ -39,7 +40,7 @@ import net.minecraft.world.entity.player.Player;
 public class FollowOwner implements AIGoal {
 
 	private final EntityMyPet petEntity;
-	private final AbstractNavigation nav;
+	private AbstractNavigation nav;
 	private int setPathTimer = 0;
 	private final float stopDistance;
 	private final double startDistance;
@@ -138,8 +139,8 @@ public class FollowOwner implements AIGoal {
 			
 			if (--this.setPathTimer <= 0) {
 				this.setPathTimer = 10;
-				if (this.nav.navigateTo(owner.getBukkitEntity())) { //TODO 2021/08/19 Seemingly not doing that properly?
-					applyWalkSpeed(); //It get's called so it returned true}
+				if (this.nav.navigateTo(owner.getBukkitEntity())) {
+					applyWalkSpeed();
 				}
 			}
 		}
@@ -165,9 +166,21 @@ public class FollowOwner implements AIGoal {
 			// make the pet faster when the player is has the SPEED effect
 			walkSpeed += owner.getEffect(MobEffects.MOVEMENT_SPEED).getAmplifier() * 0.2 * walkSpeed;
 		}
+		
+		// make aquatic pets faster - swimming is hard
+		if(owner.isInWaterOrBubble() && this.petEntity.getNavigation() instanceof MyPetWaterBoundPathNavigation) {
+			walkSpeed += 0.6f;
+			if(owner.isSwimming()) {
+				walkSpeed -= 0.035f;
+			}
+			
+			if(owner.hasEffect(MobEffects.DOLPHINS_GRACE)) {
+				walkSpeed += 0.08f;
+			}
+		}
+
 		// make the pet a little bit faster than the player so it can catch up
 		walkSpeed += 0.07f;
-
 		nav.getParameters().addSpeedModifier("FollowOwner", walkSpeed);
 	}
 }

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/MyPetAquaticMoveControl.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/movement/MyPetAquaticMoveControl.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of MyPet
+ *
+ * Copyright © 2011-2019 Keyle
+ * MyPet is licensed under the GNU Lesser General Public License.
+ *
+ * MyPet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyPet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.Keyle.MyPet.compat.v1_17_R1.entity.ai.movement;
+
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.control.MoveControl;
+
+public class MyPetAquaticMoveControl extends MoveControl{
+	private final EntityMyPet fish;
+
+	public MyPetAquaticMoveControl(EntityMyPet entityfish) {
+        super(entityfish);
+        this.fish = entityfish;
+    }
+
+    @Override
+    public void tick() {
+    	
+    	
+        if (this.operation == MoveControl.Operation.MOVE_TO && !this.fish.getNavigation().isDone()) {
+            float f = (float) (this.speedModifier * this.fish.getAttributes().getInstance(Attributes.MOVEMENT_SPEED).getValue());
+            
+            double d0 = this.wantedX - this.fish.getX();
+            double d1 = this.wantedY - this.fish.getY();
+            double d2 = this.wantedZ - this.fish.getZ();
+            
+            this.fish.setSpeed(Mth.lerp(0.125F, this.fish.getSpeed(), f));
+            
+            if(this.fish.isInWaterOrBubble()) {
+                float f3 = Mth.sin(this.mob.getXRot() * 0.017453292F);
+                this.fish.yya = -f3 * f;
+                this.fish.setDeltaMovement(this.fish.getDeltaMovement().multiply(f, 1, f));
+            }
+            
+            if (d0 != 0.0D || d2 != 0.0D) {
+                float f1 = (float) (Mth.atan2(d2, d0) * 57.2957763671875D) - 90.0F;
+
+                this.fish.setYRot(this.rotlerp(this.fish.getYRot(), f1, 90.0F));
+                this.fish.yBodyRot = this.fish.getYRot();
+            }
+            
+            if (d1 != 0.0D) {
+                double d3 = Math.sqrt(d0 * d0 + d1 * d1 + d2 * d2);
+
+                this.fish.setDeltaMovement(this.fish.getDeltaMovement().add(0.0D, (double) this.fish.getSpeed() * (d1 / d3) * 0.1D, 0.0D));
+            }
+        } else {
+        	if(this.fish.isInWaterOrBubble()) {
+        		this.fish.setDeltaMovement(this.fish.getDeltaMovement().x,-0.0045,this.fish.getDeltaMovement().z);
+        	}
+            this.fish.setSpeed(0.0F);
+        }
+    }
+}

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/navigation/MyPetWaterBoundPathNavigation.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/navigation/MyPetWaterBoundPathNavigation.java
@@ -1,0 +1,30 @@
+package de.Keyle.MyPet.compat.v1_17_R1.entity.ai.navigation;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.navigation.WaterBoundPathNavigation;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.pathfinder.AmphibiousNodeEvaluator;
+import net.minecraft.world.level.pathfinder.PathFinder;
+
+public class MyPetWaterBoundPathNavigation extends WaterBoundPathNavigation {
+	public MyPetWaterBoundPathNavigation(Mob mob, Level level) {
+        super(mob, level);
+    }
+
+    @Override
+    protected boolean canUpdatePath() {
+        return true;
+    }
+
+    @Override
+    protected PathFinder createPathFinder(int i) {
+        this.nodeEvaluator = new AmphibiousNodeEvaluator(false);
+        return new PathFinder(this.nodeEvaluator, i);
+    }
+
+    @Override
+    public boolean isStableDestination(BlockPos blockposition) {
+        return !this.level.getBlockState(blockposition.down()).isAir();
+    }
+}

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/navigation/VanillaNavigation.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/ai/navigation/VanillaNavigation.java
@@ -26,8 +26,11 @@ import org.bukkit.entity.LivingEntity;
 import de.Keyle.MyPet.api.entity.ai.navigation.AbstractNavigation;
 import de.Keyle.MyPet.api.entity.ai.navigation.NavigationParameters;
 import de.Keyle.MyPet.api.util.Compat;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.ai.movement.MyPetAquaticMoveControl;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.control.MoveControl;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
 
 @Compat("v1_17_R1")
@@ -74,6 +77,15 @@ public class VanillaNavigation extends AbstractNavigation {
 
 	@Override
 	public void tick() {
+		//This switches between movesets enabling the pet to move naturally on land and water
+		EntityMyPet petEntity = (EntityMyPet) this.entityMyPet;
+		if(petEntity.isInWaterOrBubble() && this.entityMyPet instanceof EntityMyAquaticPet
+				&& !(petEntity.getMoveControl() instanceof MyPetAquaticMoveControl)) {
+			petEntity.switchMovement(new MyPetAquaticMoveControl(petEntity));
+		} else if(!petEntity.isInWaterOrBubble() && petEntity.getMoveControl() instanceof MyPetAquaticMoveControl) {
+			petEntity.switchMovement(new MoveControl(petEntity));
+		}
+		
 		nav.tick();
 	}
 

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyAxolotl.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyAxolotl.java
@@ -20,25 +20,22 @@
 
 package de.Keyle.MyPet.compat.v1_17_R1.entity.types;
 
-import org.bukkit.block.data.Ageable;
-
 import de.Keyle.MyPet.api.Configuration;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.types.MyAxolotl;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.7F, height = 1.3F)
-public class EntityMyAxolotl extends EntityMyPet {
+public class EntityMyAxolotl extends EntityMyAquaticPet {
 
     private static final EntityDataAccessor<Boolean> AGE_WATCHER = SynchedEntityData.defineId(EntityMyAxolotl.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Integer> VARIANT_WATCHER = SynchedEntityData.defineId(EntityMyAxolotl.class, EntityDataSerializers.INT);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyCod.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyCod.java
@@ -20,20 +20,18 @@
 
 package de.Keyle.MyPet.compat.v1_17_R1.entity.types;
 
-import java.util.UUID;
-
 import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.compat.ParticleCompat;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.5F, height = 0.3f)
-public class EntityMyCod extends EntityMyPet {
+public class EntityMyCod extends EntityMyAquaticPet {
 
 	private static final EntityDataAccessor<Boolean> FROM_BUCKET_WATCHER = SynchedEntityData.defineId(EntityMyCod.class, EntityDataSerializers.BOOLEAN);
 

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyDolphin.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyDolphin.java
@@ -20,13 +20,11 @@
 
 package de.Keyle.MyPet.compat.v1_17_R1.entity.types;
 
-import java.util.UUID;
-
 import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.compat.ParticleCompat;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
@@ -34,7 +32,7 @@ import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.9F, height = 0.6f)
-public class EntityMyDolphin extends EntityMyPet {
+public class EntityMyDolphin extends EntityMyAquaticPet {
 
 	private static final EntityDataAccessor<BlockPos> TREASURE_POS_WATCHER = SynchedEntityData.defineId(EntityMyDolphin.class, EntityDataSerializers.BLOCK_POS);
 	private static final EntityDataAccessor<Boolean> GOT_FISH_WATCHER = SynchedEntityData.defineId(EntityMyDolphin.class, EntityDataSerializers.BOOLEAN);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyElderGuardian.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyElderGuardian.java
@@ -23,11 +23,11 @@ package de.Keyle.MyPet.compat.v1_17_R1.entity.types;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.types.MyElderGuardian;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.7F, height = 0.85F)
-public class EntityMyElderGuardian extends EntityMyPet {
+public class EntityMyElderGuardian extends EntityMyAquaticPet {
 
 	public EntityMyElderGuardian(Level world, MyPet myPet) {
 		super(world, myPet);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGlowSquid.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGlowSquid.java
@@ -24,11 +24,11 @@ import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.compat.ParticleCompat;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.7F, height = 0.475f)
-public class EntityMyGlowSquid extends EntityMyPet {
+public class EntityMyGlowSquid extends EntityMyAquaticPet {
 
 	public EntityMyGlowSquid(Level world, MyPet myPet) {
 		super(world, myPet);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGuardian.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGuardian.java
@@ -23,11 +23,11 @@ package de.Keyle.MyPet.compat.v1_17_R1.entity.types;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.types.MyGuardian;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.7F, height = 0.85F)
-public class EntityMyGuardian extends EntityMyPet {
+public class EntityMyGuardian extends EntityMyAquaticPet {
 
 	public EntityMyGuardian(Level world, MyPet myPet) {
 		super(world, myPet);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyOcelot.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyOcelot.java
@@ -79,7 +79,7 @@ public class EntityMyOcelot extends EntityMyPet {
 				}
 			}
 		}
-		return InteractionResult.CONSUME;
+		return InteractionResult.PASS;
 	}
 
 	@Override

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPufferfish.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPufferfish.java
@@ -25,14 +25,14 @@ import de.Keyle.MyPet.api.compat.ParticleCompat;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.types.MyPufferfish;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.5F, height = 0.5f)
-public class EntityMyPufferfish extends EntityMyPet {
+public class EntityMyPufferfish extends EntityMyAquaticPet {
 
 	private static final EntityDataAccessor<Boolean> FROM_BUCKET_WATCHER = SynchedEntityData.defineId(EntityMyPufferfish.class, EntityDataSerializers.BOOLEAN);
 	private static final EntityDataAccessor<Integer> PUFF_WATCHER = SynchedEntityData.defineId(EntityMyPufferfish.class, EntityDataSerializers.INT);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyRavager.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyRavager.java
@@ -73,7 +73,7 @@ public class EntityMyRavager extends EntityMyPet {
 
 	@Override
 	public InteractionResult handlePlayerInteraction(Player entityhuman, InteractionHand enumhand, ItemStack itemStack) {
-		if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+		if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
 			if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
 				getOwner().sendMessage("Unfortunately, Ravagers can not be ridden (Minecraft limitation)", 5000);
 				return InteractionResult.CONSUME;

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMySalmon.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMySalmon.java
@@ -24,14 +24,14 @@ import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.compat.ParticleCompat;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.7F, height = 0.4f)
-public class EntityMySalmon extends EntityMyPet {
+public class EntityMySalmon extends EntityMyAquaticPet {
 
 	private static final EntityDataAccessor<Boolean> FROM_BUCKET_WATCHER = SynchedEntityData.defineId(EntityMySalmon.class, EntityDataSerializers.BOOLEAN);
 

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMySquid.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMySquid.java
@@ -24,11 +24,11 @@ import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.compat.ParticleCompat;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.7F, height = 0.475f)
-public class EntityMySquid extends EntityMyPet {
+public class EntityMySquid extends EntityMyAquaticPet {
 
 	public EntityMySquid(Level world, MyPet myPet) {
 		super(world, myPet);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyTropicalFish.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyTropicalFish.java
@@ -25,14 +25,14 @@ import de.Keyle.MyPet.api.compat.ParticleCompat;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.types.MyTropicalFish;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 0.5F, height = 0.4f)
-public class EntityMyTropicalFish extends EntityMyPet {
+public class EntityMyTropicalFish extends EntityMyAquaticPet {
 
 	private static final EntityDataAccessor<Boolean> FROM_BUCKET_WATCHER = SynchedEntityData.defineId(EntityMyTropicalFish.class, EntityDataSerializers.BOOLEAN);
 	private static final EntityDataAccessor<Integer> VARIANT_WATCHER = SynchedEntityData.defineId(EntityMyTropicalFish.class, EntityDataSerializers.INT);

--- a/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyTurtle.java
+++ b/modules/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyTurtle.java
@@ -24,7 +24,7 @@ import de.Keyle.MyPet.api.Configuration;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.types.MyTurtle;
-import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyPet;
+import de.Keyle.MyPet.compat.v1_17_R1.entity.EntityMyAquaticPet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
@@ -36,7 +36,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 @EntitySize(width = 1.2F, height = 0.4F)
-public class EntityMyTurtle extends EntityMyPet {
+public class EntityMyTurtle extends EntityMyAquaticPet {
 
 	private static final EntityDataAccessor<Boolean> AGE_WATCHER = SynchedEntityData.defineId(EntityMyTurtle.class, EntityDataSerializers.BOOLEAN);
 	private static final EntityDataAccessor<BlockPos> HOME_WATCHER = SynchedEntityData.defineId(EntityMyTurtle.class, EntityDataSerializers.BLOCK_POS);

--- a/modules/v1_8_R3/src/main/java/de/Keyle/MyPet/compat/v1_8_R3/entity/EntityMyPet.java
+++ b/modules/v1_8_R3/src/main/java/de/Keyle/MyPet/compat/v1_8_R3/entity/EntityMyPet.java
@@ -432,7 +432,7 @@ public abstract class EntityMyPet extends EntityCreature implements IAnimal, MyP
 
         if (isMyPet() && myPet.getOwner().equals(entityhuman)) {
             Player owner = this.getOwner().getPlayer();
-            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
                 if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
                     if (Permissions.hasExtended(owner, "MyPet.extended.ride")) {
                         entityhuman.mount(this);

--- a/modules/v1_8_R3/src/main/java/de/Keyle/MyPet/compat/v1_8_R3/entity/ai/movement/Control.java
+++ b/modules/v1_8_R3/src/main/java/de/Keyle/MyPet/compat/v1_8_R3/entity/ai/movement/Control.java
@@ -49,7 +49,7 @@ public class Control implements AIGoal, Scheduler {
 
     @Override
     public boolean shouldStart() {
-        if (!this.myPet.getEntity().get().canMove()) {
+        if (this.myPet.getEntity().isEmpty() || !this.myPet.getEntity().get().canMove()) {
             return false;
         }
         ControlImpl controlSkill = myPet.getSkills().get(ControlImpl.class);

--- a/modules/v1_9_R2/src/main/java/de/Keyle/MyPet/compat/v1_9_R2/entity/EntityMyPet.java
+++ b/modules/v1_9_R2/src/main/java/de/Keyle/MyPet/compat/v1_9_R2/entity/EntityMyPet.java
@@ -430,7 +430,7 @@ public abstract class EntityMyPet extends EntityCreature implements IAnimal, MyP
         Player owner = this.getOwner().getPlayer();
 
         if (isMyPet() && myPet.getOwner().equals(entityhuman)) {
-            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
                 if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
                     if (Permissions.hasExtended(owner, "MyPet.extended.ride")) {
                         ((CraftPlayer) owner).getHandle().startRiding(this);

--- a/modules/v1_9_R2/src/main/java/de/Keyle/MyPet/compat/v1_9_R2/entity/ai/movement/Control.java
+++ b/modules/v1_9_R2/src/main/java/de/Keyle/MyPet/compat/v1_9_R2/entity/ai/movement/Control.java
@@ -49,7 +49,7 @@ public class Control implements AIGoal, Scheduler {
 
     @Override
     public boolean shouldStart() {
-        if (!this.myPet.getEntity().get().canMove()) {
+        if (this.myPet.getEntity().isEmpty() || !this.myPet.getEntity().get().canMove()) {
             return false;
         }
         ControlImpl controlSkill = myPet.getSkills().get(ControlImpl.class);

--- a/modules/v1_9_R2/src/main/java/de/Keyle/MyPet/compat/v1_9_R2/entity/types/EntityMyPig.java
+++ b/modules/v1_9_R2/src/main/java/de/Keyle/MyPet/compat/v1_9_R2/entity/types/EntityMyPig.java
@@ -20,17 +20,30 @@
 
 package de.Keyle.MyPet.compat.v1_9_R2.entity.types;
 
+import org.bukkit.craftbukkit.v1_9_R2.inventory.CraftItemStack;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
 import de.Keyle.MyPet.MyPetApi;
 import de.Keyle.MyPet.api.Configuration;
 import de.Keyle.MyPet.api.entity.EntitySize;
 import de.Keyle.MyPet.api.entity.MyPet;
 import de.Keyle.MyPet.api.entity.types.MyPig;
+import de.Keyle.MyPet.api.plugin.MyPetPlugin;
 import de.Keyle.MyPet.compat.v1_9_R2.entity.EntityMyPet;
 import de.Keyle.MyPet.skill.skills.RideImpl;
-import net.minecraft.server.v1_9_R2.*;
-import org.bukkit.craftbukkit.v1_9_R2.inventory.CraftItemStack;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import net.minecraft.server.v1_9_R2.DataWatcher;
+import net.minecraft.server.v1_9_R2.DataWatcherObject;
+import net.minecraft.server.v1_9_R2.DataWatcherRegistry;
+import net.minecraft.server.v1_9_R2.EntityHuman;
+import net.minecraft.server.v1_9_R2.EntityItem;
+import net.minecraft.server.v1_9_R2.EntityPlayer;
+import net.minecraft.server.v1_9_R2.EnumHand;
+import net.minecraft.server.v1_9_R2.ItemStack;
+import net.minecraft.server.v1_9_R2.Items;
+import net.minecraft.server.v1_9_R2.PacketPlayOutAttachEntity;
+import net.minecraft.server.v1_9_R2.World;
+import net.minecraft.server.v1_9_R2.WorldServer;
 
 @EntitySize(width = 0.7F, height = 0.9F)
 public class EntityMyPig extends EntityMyPet {
@@ -79,7 +92,7 @@ public class EntityMyPig extends EntityMyPet {
         }
 
         if (isMyPet() && myPet.getOwner().equals(entityhuman)) {
-            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
+            if (Configuration.Skilltree.Skill.Ride.RIDE_ITEM == null || Configuration.Skilltree.Skill.Ride.RIDE_ITEM.compare(itemStack)) {
                 if (myPet.getSkills().isActive(RideImpl.class) && canMove()) {
                     if (itemStack != null && itemStack.getItem() == Items.LEAD) {
                         ((WorldServer) this.world).getTracker().a(this, new PacketPlayOutAttachEntity(this, null));

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         </repository>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/scomans/*</url>
+            <url>https://maven.pkg.github.com/MyPetORG/*</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>
@@ -528,9 +528,9 @@
     </dependencies>
 
     <scm>
-        <connection>scm:git:git@github.com:scomans/MyPet.git</connection>
-        <developerConnection>scm:git:git@github.com:scomans/MyPet.git</developerConnection>
-        <url>https://github.com/scomans/MyPet/tree/master/</url>
+        <connection>scm:git:git@github.com:MyPetORG/MyPet.git</connection>
+        <developerConnection>scm:git:git@github.com:MyPetORG/MyPet.git</developerConnection>
+        <url>https://github.com/MyPetORG/MyPet/tree/master/</url>
     </scm>
 
     <build>


### PR DESCRIPTION
New:
- You can now swim with your (aquatic) pets - This feature is 1.17 only for now but I'm planning to backport it
- Aquatic pets will now also spawn under water - 1.17 only again
- You can now set the ride-item to NONE
- Pet Death-Messages will not be shown if the gamerule SHOW_DEATH_MESSAGES is set to false anymore

Fixes:
- Fixed a bug where the Item-Tooltip on `/petadmin release` would stay empty (1.13 and up)
- Fixed a bug where the player would not be able to tell an Ocelot to stay put (1.16 and up)

About the swimming:
This might still be a bit buggy/strange as this is the first iteration of the feature