### PR TITLE
perf: remove unused stacktrace in PlatformHelper#getEntity

### DIFF
--- a/modules/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/PlatformHelper.java
+++ b/modules/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/PlatformHelper.java
@@ -355,7 +355,6 @@ public class PlatformHelper extends de.Keyle.MyPet.api.PlatformHelper {
 
     @Override
     public Entity getEntity(int id, World world) {
-        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
     	net.minecraft.world.entity.Entity e = ((CraftWorld) world).getHandle().getEntities().get(id);
         if(e==null) {
             Int2ObjectMap dragonParts = (Int2ObjectMap) ReflectionUtil.getFieldValue(dragonPartsField, ((CraftWorld)world).getHandle());


### PR DESCRIPTION
Currently, in the 1.19 PlatformHelper, there is a line that creates a stacktrace for every getEntity call. This causes a significant performance regression compared to other versions.

![image](https://user-images.githubusercontent.com/22900187/176030518-2aa54a24-6975-4653-b898-aed86fa8de01.png)
