### PR TITLE
fix: leash and off-hand interactions

### DIFF
--- a/modules/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/PlatformHelper.java
+++ b/modules/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/PlatformHelper.java
@@ -355,7 +355,6 @@ public class PlatformHelper extends de.Keyle.MyPet.api.PlatformHelper {
 
     @Override
     public Entity getEntity(int id, World world) {
-        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
     	net.minecraft.world.entity.Entity e = ((CraftWorld) world).getHandle().getEntities().get(id);
         if(e==null) {
             Int2ObjectMap dragonParts = (Int2ObjectMap) ReflectionUtil.getFieldValue(dragonPartsField, ((CraftWorld)world).getHandle());


### PR DESCRIPTION
Currently, right-clicking on a pet entity with an empty hand will swing the off-hand. This behavior is unintended, and does not match vanilla.

![image](https://user-images.githubusercontent.com/22900187/176036631-54291230-ed5d-4b2d-b0de-67d77af4c1c8.png)

I have also cleaned up leash interactions in this PR. Currently, when a pet entity is right-clicked with a lead, a Bukkit scheduler task is created to run 5 ticks later and update the client leash state. Instead, we can move the synchronization code into an overridden vanilla method.

![image](https://user-images.githubusercontent.com/22900187/176037033-0f977af2-20da-452b-86d7-2421eb4be922.png)