### PR TITLE
Added Skilltree#getWeight(), why was this used while it didnt exist?

### DIFF
--- a/modules/API/src/main/java/de/Keyle/MyPet/api/skill/skilltree/Skilltree.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/skill/skilltree/Skilltree.java
@@ -97,6 +97,9 @@ public class Skilltree {
     public void setMaxLevel(int maxLevel) {
         this.maxLevel = maxLevel < 0 ? 0 : Math.min(maxLevel, Configuration.LevelSystem.Experience.LEVEL_CAP);
     }
+    public double getWeight() {
+        return weight;
+    }
 
     public int getRequiredLevel() {
         return requiredLevel;


### PR DESCRIPTION
If this isnt supposed to be there then just close the request, i just went to the SkilltreeManager class and found that this didnt exist