### PR TITLE
Added TabComplete for pettrade command

### DIFF
--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandTrade.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandTrade.java
@@ -272,6 +272,11 @@ public class CommandTrade implements CommandTabCompleter {
             if (offers.containsKey(((Player) sender).getUniqueId())) {
                 return filterTabCompletionResults(tradeList, strings[0]);
             }
+            List<String> playerNames = new ArrayList<>();
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                playerNames.add(player.getName());
+            }
+            return filterTabCompletionResults(playerNames, strings[0]);
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
Just got notified that /pettrade has no tab completion for players. Therefore, I added it for people that are not in an offer yet
