### PR TITLE
Fixing client-crashes related to the Mooshroom-pet

### DIFF
--- a/modules/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyMooshroom.java
+++ b/modules/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyMooshroom.java
@@ -42,7 +42,7 @@ import net.minecraft.world.level.Level;
 public class EntityMyMooshroom extends EntityMyPet {
 
 	private static final EntityDataAccessor<Boolean> AGE_WATCHER = SynchedEntityData.defineId(EntityMyMooshroom.class, EntityDataSerializers.BOOLEAN);
-	private static final EntityDataAccessor<String> COLOR_WATCHER = SynchedEntityData.defineId(EntityMyMooshroom.class, EntityDataSerializers.STRING);
+	private static final EntityDataAccessor<Integer> COLOR_WATCHER = SynchedEntityData.defineId(EntityMyMooshroom.class, EntityDataSerializers.INT);
 
 	public EntityMyMooshroom(Level world, MyPet myPet) {
 		super(world, myPet);
@@ -110,13 +110,13 @@ public class EntityMyMooshroom extends EntityMyPet {
 	protected void defineSynchedData(SynchedEntityData.Builder builder) {
 		super.defineSynchedData(builder);
 		builder.define(AGE_WATCHER, false);
-		builder.define(COLOR_WATCHER, "red");
+		builder.define(COLOR_WATCHER, MyMooshroom.Type.Red.ordinal());
 	}
 
 	@Override
 	public void updateVisuals() {
 		this.getEntityData().set(AGE_WATCHER, getMyPet().isBaby());
-		this.getEntityData().set(COLOR_WATCHER, getMyPet().getType().getType());
+		this.getEntityData().set(COLOR_WATCHER, getMyPet().getType().ordinal());
 	}
 
 	@Override


### PR DESCRIPTION
Version `v1_21_R4` changed the data-type of the colour data-watcher for mushroom-cows from a string-literal to an integer, which simply maps `0` to `RED` and `1` to `BROWN`; I've used the enum-ordinal to represent this mapping, as to allow for easy future additions.