### PR TITLE
Fixing StringTag value-access

### DIFF
--- a/modules/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/util/inventory/ItemStackNBTConverter.java
+++ b/modules/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/util/inventory/ItemStackNBTConverter.java
@@ -152,7 +152,7 @@ public class ItemStackNBTConverter {
             case 7:
                 return new TagByteArray(((ByteArrayTag) vanillaTag).getAsByteArray());
             case 8:
-                return new TagString(vanillaTag.toString());
+                return new TagString(((StringTag) vanillaTag).value());
             case 9:
                 ListTag tagList = (ListTag) vanillaTag;
                 List compoundList = new ArrayList();


### PR DESCRIPTION
I totally messed up and assumed that `toString` would yield the string contents - it actually stringifies the tag, appending surrounding quotes (`"`); this mistake caused many issues, one of them being item-serialization. Sorry!