### PR TITLE
Fix accidental version omission

### DIFF
--- a/modules/API/src/main/java/de/Keyle/MyPet/api/util/service/types/RepositoryMyPetConverterService.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/util/service/types/RepositoryMyPetConverterService.java
@@ -54,6 +54,7 @@ public class RepositoryMyPetConverterService implements ServiceContainer {
         v1_16_R2,
         v1_16_R3,
         v1_17_R1,
+        v1_18_R1,
         v1_18_R2,
         v1_19_R1,
         v1_19_R2,


### PR DESCRIPTION
Does not re-add 1.18.0 support, just fixes the Version enum