### PR TITLE
perf: cache version comparison in ProtocolLibHook hot path

### DIFF
--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,3 +1,4 @@
+- (b2) Fixed MyPet crashing on startup when the server's SQLite database driver failed to load (e.g. the driver doesn't exist)
 - (b2) Fixed an error when a Pet wearing or holding equipment came into view of a player on 1.21 and newer
 - (b2) Fixed MyPet failing to hook into MobStacker (kiwifisher)
 - (b2) Fixed Pet melee and ranged attacks ignoring damage reductions applied by other plugins (such as custom armor/defense systems)

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -4,6 +4,7 @@
 - (b3) Fixed a NullPointerException when interacting with a Pet type that has no leash item configured 
 - (b3) Fixed MyPet failing to load when the WorldGuard hook can't initialize on some Java 25 server builds
 - (b3) Fixed an error when a Pet Chicken tried to lay an egg on some 1.26.2 Paper builds
+- (b3) Fixed a rare error that could occur when another player disconnected while a Pet was still being summoned
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
 - (b2) Fixed Phantom Pets slowing down to a near-standstill when they target a mob

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,5 +1,6 @@
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
+- (b2) Fixed an error that could occur on older server versions while a player was still connecting to the server
 - (b2) Fixed MyPet logging a false "connection leak detected" warning during startup or reload on MySQL setups with large databases or slow connections
 - (b2) Fixed an error that could occur when a player changed worlds (e.g. through a portal teleport) while their Pet was unavailable or they were disconnecting
 - (b2) Fixed error when a Pet's food list in pet-config.yml contained an invalid or "none" entry

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,3 +1,5 @@
+- (b2) Updated bStats to 3.1.0
+- (b2) Disabled bStats reporting for local builds
 - (b2) Fixed Pet ranged attacks not dealing damage to the opposing Pet during a duel
 - (b2) Fixed MyPet crashing on startup when the server's SQLite database driver failed to load (e.g. the driver doesn't exist)
 - (b2) Fixed an error when a Pet wearing or holding equipment came into view of a player on 1.21 and newer

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,6 +1,7 @@
+- (b2) Fixed an error when a Pet wearing or holding equipment came into view of a player on 1.21 and newer
 - (b2) Fixed MyPet failing to hook into MobStacker (kiwifisher)
 - (b2) Fixed Pet melee and ranged attacks ignoring damage reductions applied by other plugins (such as custom armor/defense systems)
-- (b2) Fixed a startup crash that could occur when a bundled file (skilltrees, pet-shops.yml, etc.) was missing from the MyPet jar
+- (b2) Fixed an error when a bundled file (skilltrees, pet-shops.yml, etc.) was missing from the MyPet jar
 - (b1) MyPet now disables with a clear message on unsupported Minecraft versions
 - (b1) MyPet now disables with a clear message on unsupported Forge-Bukkit hybrid servers (Arclight, Mohist) instead of crashing during startup
 - (b1) Fixed a bug that sometimes caused NBT data loss when items had data from third party plugins

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,5 +1,6 @@
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
+- (b2) Fixed MyPet logging a false "connection leak detected" warning during startup or reload on MySQL setups with large databases or slow connections
 - (b2) Fixed an error that could occur when a player changed worlds (e.g. through a portal teleport) while their Pet was unavailable or they were disconnecting
 - (b2) Fixed error when a Pet's food list in pet-config.yml contained an invalid or "none" entry
 - (b2) Fixed Pet ranged attacks not dealing damage to the opposing Pet during a duel

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,3 +1,9 @@
+- (b3) Added end-of-life messaging upon startup
+- (b3) Fixed Pets failing to match their owner's walk speed on some 1.26.2 Paper builds 
+- (b3) Fixed a NullPointerException when a Pet-owning player took damage 
+- (b3) Fixed a NullPointerException when interacting with a Pet type that has no leash item configured 
+- (b3) Fixed MyPet failing to load when the WorldGuard hook can't initialize on some Java 25 server builds
+- (b3) Fixed an error when a Pet Chicken tried to lay an egg on some 1.26.2 Paper builds
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
 - (b2) Fixed Phantom Pets slowing down to a near-standstill when they target a mob

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -5,6 +5,7 @@
 - (b3) Fixed MyPet failing to load when the WorldGuard hook can't initialize on some Java 25 server builds
 - (b3) Fixed an error when a Pet Chicken tried to lay an egg on some 1.26.2 Paper builds
 - (b3) Fixed a rare error that could occur when another player disconnected while a Pet was still being summoned
+- (b3) Fixed a rare error when a Pet's equipment was displayed to a nearby player right as the Pet was still being summoned
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
 - (b2) Fixed Phantom Pets slowing down to a near-standstill when they target a mob

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,3 +1,4 @@
+- (b2) Fixed Pet ranged attacks not dealing damage to the opposing Pet during a duel
 - (b2) Fixed MyPet crashing on startup when the server's SQLite database driver failed to load (e.g. the driver doesn't exist)
 - (b2) Fixed an error when a Pet wearing or holding equipment came into view of a player on 1.21 and newer
 - (b2) Fixed MyPet failing to hook into MobStacker (kiwifisher)

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,3 +1,4 @@
+- (b2) Fixed error when a Pet's food list in pet-config.yml contained an invalid or "none" entry
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
 - (b2) Fixed Pet ranged attacks not dealing damage to the opposing Pet during a duel

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,3 +1,4 @@
+- (b2) Fixed MyPet failing to hook into MobStacker (kiwifisher)
 - (b2) Fixed Pet melee and ranged attacks ignoring damage reductions applied by other plugins (such as custom armor/defense systems)
 - (b2) Fixed a startup crash that could occur when a bundled file (skilltrees, pet-shops.yml, etc.) was missing from the MyPet jar
 - (b1) MyPet now disables with a clear message on unsupported Minecraft versions

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,6 +1,7 @@
-- (b2) Fixed error when a Pet's food list in pet-config.yml contained an invalid or "none" entry
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
+- (b2) Fixed an error that could occur when a player changed worlds (e.g. through a portal teleport) while their Pet was unavailable or they were disconnecting
+- (b2) Fixed error when a Pet's food list in pet-config.yml contained an invalid or "none" entry
 - (b2) Fixed Pet ranged attacks not dealing damage to the opposing Pet during a duel
 - (b2) Fixed MyPet crashing on startup when the server's SQLite database driver failed to load (e.g. the driver doesn't exist)
 - (b2) Fixed an error when a Pet wearing or holding equipment came into view of a player on 1.21 and newer

--- a/.github/changelogs/3.14.3-SNAPSHOT.md
+++ b/.github/changelogs/3.14.3-SNAPSHOT.md
@@ -1,5 +1,6 @@
 - (b2) Updated bStats to 3.1.0
 - (b2) Disabled bStats reporting for local builds
+- (b2) Fixed Phantom Pets slowing down to a near-standstill when they target a mob
 - (b2) Fixed an error that could occur on older server versions while a player was still connecting to the server
 - (b2) Fixed MyPet logging a false "connection leak detected" warning during startup or reload on MySQL setups with large databases or slow connections
 - (b2) Fixed an error that could occur when a player changed worlds (e.g. through a portal teleport) while their Pet was unavailable or they were disconnecting

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,6 +21,7 @@ jobs:
       WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
       GH_TOKEN: ${{ secrets.TOKEN_GITHUB }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       HANGAR_TOKEN: ${{ secrets.HANGAR_TOKEN }}
       MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
 

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -25,6 +25,7 @@ jobs:
       WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
       GH_TOKEN: ${{ secrets.TOKEN_GITHUB }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       HANGAR_TOKEN: ${{ secrets.HANGAR_TOKEN }}
       MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <img src=".github/readme-images/logo.png" alt="MyPet" width="200">
 </a>
 
+> [!WARNING]
+> **MyPet 3.x has reached end of life** and no longer receives substantive updates. Please migrate to [MyPet v4](https://builtbybit.com/resources/mypet-4.115339/).
+
 ## MyPet - The extensive pet plugin
 MyPet is a highly customizable pet plugin with a lot of features.<br />
 Take them on a lead, train them and make them a very powerful companion!

--- a/api/src/main/java/de/Keyle/MyPet/api/MyPetVersion.java
+++ b/api/src/main/java/de/Keyle/MyPet/api/MyPetVersion.java
@@ -36,6 +36,7 @@ public class MyPetVersion {
     private static String version = "0.0.0";
     private static String build = "";
     private static String buildType = "local";
+    private static String sentryDsn = "";
     private static String minecraftVersion = "0.0.0";
     private static List<String> bukkitPackets = new ArrayList<>();
     private static List<String> specialMCVersions = new ArrayList<>();
@@ -54,6 +55,9 @@ public class MyPetVersion {
             }
             if ((val = attr.getValue("Project-Type")) != null && !val.isEmpty()) {
                 buildType = val;
+            }
+            if ((val = attr.getValue("Sentry-Dsn")) != null) {
+                sentryDsn = val;
             }
             if (attr.getValue("Project-Minecraft-Version") != null) {
                 minecraftVersion = attr.getValue("Project-Minecraft-Version");
@@ -111,6 +115,14 @@ public class MyPetVersion {
             updated = true;
         }
         return build;
+    }
+
+    public static String getSentryDsn() {
+        if (!updated) {
+            loadData();
+            updated = true;
+        }
+        return sentryDsn;
     }
 
     public static String getFormattedVersion() {

--- a/api/src/main/java/de/Keyle/MyPet/api/repository/RepositoryInitException.java
+++ b/api/src/main/java/de/Keyle/MyPet/api/repository/RepositoryInitException.java
@@ -21,9 +21,10 @@
 package de.Keyle.MyPet.api.repository;
 
 public class RepositoryInitException extends Exception {
-    final public Exception exception;
+    final public Throwable exception;
 
-    public RepositoryInitException(Exception e) {
+    public RepositoryInitException(Throwable e) {
+        super(e);
         exception = e;
     }
 

--- a/api/src/main/java/de/Keyle/MyPet/api/util/CompatUtil.java
+++ b/api/src/main/java/de/Keyle/MyPet/api/util/CompatUtil.java
@@ -127,15 +127,16 @@ public class CompatUtil {
     }
 
     public int compareWithMinecraftVersion(String version) {
-        if (VERSION_MATCHER.matcher(version).find()) {
-            if (compareCache.containsKey(minecraftVersion + "-::-" + version)) {
-                return compareCache.get(minecraftVersion + "-::-" + version);
-            }
-            int compare = Util.versionCompare(minecraftVersion, version);
-            compareCache.put(minecraftVersion + "-::-" + version, compare);
-            return compare;
+        Integer cached = compareCache.get(version);
+        if (cached != null) {
+            return cached;
         }
-        throw new IllegalArgumentException("\"version\" must be a valid Minecraft version. \"" + version + "\" given.");
+        if (!VERSION_MATCHER.matcher(version).find()) {
+            throw new IllegalArgumentException("\"version\" must be a valid Minecraft version. \"" + version + "\" given.");
+        }
+        int compare = Util.versionCompare(minecraftVersion, version);
+        compareCache.put(version, compare);
+        return compare;
     }
 
     private String getBukkitVersionFromMinecraftVersion() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,6 +140,10 @@ tasks.named<ProcessResources>("processResources") {
     filesMatching("*.yml") { expand(filteringProps) }
 }
 
+// Only the official CI has this secret. Forks and self-compiled builds get an empty DSN, so
+// SentryErrorReporter stays disabled instead of silently reporting a fork's errors to our project.
+val sentryDsn = System.getenv("SENTRY_DSN") ?: ""
+
 fun Manifest.attributesForMyPet() = attributes(
     mapOf(
         "Class-Path" to "MyPet/rhino.jar MyPet/rhino-1.7.9.jar MyPet/rhino-1.7.10.jar MyPet/rhino-1.7.15.jar ../MyPet/rhino.jar ../MyPet/rhino-1.7.9.jar ../MyPet/rhino-1.7.10.jar ../MyPet/rhino-1.7.15.jar MyPet/mongo-java-driver.jar MyPet/mongo-java-driver-3.12.11.jar",
@@ -151,7 +155,8 @@ fun Manifest.attributesForMyPet() = attributes(
         "Project-Minecraft-Version" to minecraftVersion,
         "Project-Bukkit-Packets" to bukkitPackets,
         "Special-MC-Versions" to specialVersions,
-        "Git-Commit" to (System.getenv("GIT_COMMIT") ?: "")
+        "Git-Commit" to (System.getenv("GIT_COMMIT") ?: ""),
+        "Sentry-Dsn" to sentryDsn
     )
 )
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,7 +181,7 @@ dependencies {
 
     // External libs to be shaded
 
-    add("shade", "org.bstats:bstats-bukkit:1.7")
+    add("shade", "org.bstats:bstats-bukkit:3.1.0")
     add("shade", "org.mongodb:mongodb-driver:3.12.11")
     add("shade", "de.keyle:knbt:0.0.6")
     add("shade", "com.google.code.gson:gson:2.8.9")

--- a/nms/v1_12_R1/src/main/java/de/Keyle/MyPet/compat/v1_12_R1/entity/EntityMyPet.java
+++ b/nms/v1_12_R1/src/main/java/de/Keyle/MyPet/compat/v1_12_R1/entity/EntityMyPet.java
@@ -611,6 +611,10 @@ public abstract class EntityMyPet extends EntityCreature implements IAnimal, MyP
     }
 
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttributeInstance(GenericAttributes.maxHealth).getValue() != maxHealth;

--- a/nms/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/EntityMyPet.java
+++ b/nms/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/EntityMyPet.java
@@ -647,6 +647,9 @@ public abstract class EntityMyPet extends EntityInsentient implements MyPetMinec
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = this.datawatcher.get(HEALTH);
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -658,6 +661,10 @@ public abstract class EntityMyPet extends EntityInsentient implements MyPetMinec
 
 	@Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttributeInstance(GenericAttributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/types/EntityMyPhantom.java
+++ b/nms/v1_16_R3/src/main/java/de/Keyle/MyPet/compat/v1_16_R3/entity/types/EntityMyPhantom.java
@@ -65,7 +65,7 @@ public class EntityMyPhantom extends EntityMyPet {
 		getDataWatcher().set(SIZE_WATCHER, size);
 		this.updateSize();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/EntityMyPet.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/EntityMyPet.java
@@ -678,6 +678,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -689,6 +692,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyDrowned.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyDrowned.java
@@ -199,7 +199,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyEvoker.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyEvoker.java
@@ -174,7 +174,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyFox.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyFox.java
@@ -202,7 +202,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGiant.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGiant.java
@@ -158,7 +158,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyHorse.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyHorse.java
@@ -283,7 +283,7 @@ public class EntityMyHorse extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyHusk.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyHusk.java
@@ -197,7 +197,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyIllusioner.java
@@ -197,7 +197,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPhantom.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPiglin.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPiglin.java
@@ -186,7 +186,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPiglinBrute.java
@@ -169,7 +169,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPillager.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyPillager.java
@@ -198,7 +198,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMySkeleton.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMySkeleton.java
@@ -176,7 +176,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyStray.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyStray.java
@@ -156,7 +156,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyVex.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyVex.java
@@ -181,7 +181,7 @@ public class EntityMyVex extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyVillager.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyVindicator.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyVindicator.java
@@ -201,7 +201,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyWitherSkeleton.java
@@ -156,7 +156,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyZombie.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyZombie.java
@@ -197,7 +197,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyZombifiedPiglin.java
@@ -182,7 +182,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/EntityMyPet.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/EntityMyPet.java
@@ -678,6 +678,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -689,6 +692,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyDrowned.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyDrowned.java
@@ -199,7 +199,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyEvoker.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyEvoker.java
@@ -174,7 +174,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyFox.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyFox.java
@@ -202,7 +202,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyGiant.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyGiant.java
@@ -158,7 +158,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyHorse.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyHorse.java
@@ -283,7 +283,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyHusk.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyHusk.java
@@ -197,7 +197,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyIllusioner.java
@@ -197,7 +197,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPhantom.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPiglin.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPiglin.java
@@ -186,7 +186,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPiglinBrute.java
@@ -170,7 +170,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPillager.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyPillager.java
@@ -198,7 +198,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMySkeleton.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMySkeleton.java
@@ -176,7 +176,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyStray.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyStray.java
@@ -156,7 +156,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyVex.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyVex.java
@@ -181,7 +181,7 @@ public class EntityMyVex extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyVillager.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyVindicator.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyVindicator.java
@@ -202,7 +202,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyWitherSkeleton.java
@@ -156,7 +156,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyZombie.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyZombie.java
@@ -197,7 +197,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyZombifiedPiglin.java
@@ -182,7 +182,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/EntityMyPet.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/EntityMyPet.java
@@ -678,6 +678,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -689,6 +692,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyAllay.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyAllay.java
@@ -179,7 +179,7 @@ public class EntityMyAllay extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyDrowned.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyDrowned.java
@@ -198,7 +198,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyEvoker.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyEvoker.java
@@ -173,7 +173,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyFox.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyFox.java
@@ -201,7 +201,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyGiant.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyGiant.java
@@ -157,7 +157,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyHorse.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyHorse.java
@@ -282,7 +282,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyHusk.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyHusk.java
@@ -196,7 +196,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyIllusioner.java
@@ -196,7 +196,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPhantom.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPiglin.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPiglin.java
@@ -185,7 +185,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPiglinBrute.java
@@ -169,7 +169,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPillager.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyPillager.java
@@ -197,7 +197,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMySkeleton.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMySkeleton.java
@@ -175,7 +175,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyStray.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyStray.java
@@ -155,7 +155,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyVex.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyVex.java
@@ -181,7 +181,7 @@ public class EntityMyVex extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyVillager.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyVillager.java
@@ -178,7 +178,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyVindicator.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyVindicator.java
@@ -201,7 +201,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyWitherSkeleton.java
@@ -155,7 +155,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyZombie.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyZombie.java
@@ -196,7 +196,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyZombieVillager.java
@@ -210,7 +210,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyZombifiedPiglin.java
@@ -181,7 +181,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/EntityMyPet.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/EntityMyPet.java
@@ -680,6 +680,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -691,6 +694,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyAllay.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyAllay.java
@@ -180,7 +180,7 @@ public class EntityMyAllay extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyDrowned.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyDrowned.java
@@ -199,7 +199,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyEvoker.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyEvoker.java
@@ -174,7 +174,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyFox.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyFox.java
@@ -202,7 +202,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyGiant.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyGiant.java
@@ -158,7 +158,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyHorse.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyHorse.java
@@ -283,7 +283,7 @@ public class EntityMyHorse extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyHusk.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyHusk.java
@@ -197,7 +197,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyIllusioner.java
@@ -197,7 +197,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPhantom.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPiglin.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPiglin.java
@@ -186,7 +186,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPiglinBrute.java
@@ -170,7 +170,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPillager.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyPillager.java
@@ -198,7 +198,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMySkeleton.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMySkeleton.java
@@ -176,7 +176,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyStray.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyStray.java
@@ -156,7 +156,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyVex.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyVex.java
@@ -181,7 +181,7 @@ public class EntityMyVex extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyVillager.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyVindicator.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyVindicator.java
@@ -202,7 +202,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyWitherSkeleton.java
@@ -156,7 +156,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyZombie.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyZombie.java
@@ -197,7 +197,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyZombifiedPiglin.java
@@ -182,7 +182,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/EntityMyPet.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/EntityMyPet.java
@@ -680,6 +680,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -691,6 +694,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyAllay.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyAllay.java
@@ -180,7 +180,7 @@ public class EntityMyAllay extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyDrowned.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyDrowned.java
@@ -199,7 +199,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyEvoker.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyEvoker.java
@@ -174,7 +174,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyFox.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyFox.java
@@ -202,7 +202,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyGiant.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyGiant.java
@@ -158,7 +158,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyHorse.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyHorse.java
@@ -279,7 +279,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyHusk.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyHusk.java
@@ -197,7 +197,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyIllusioner.java
@@ -197,7 +197,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPhantom.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPiglin.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPiglin.java
@@ -186,7 +186,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPiglinBrute.java
@@ -170,7 +170,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPillager.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyPillager.java
@@ -198,7 +198,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMySkeleton.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMySkeleton.java
@@ -176,7 +176,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyStray.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyStray.java
@@ -156,7 +156,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyVex.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyVex.java
@@ -181,7 +181,7 @@ public class EntityMyVex extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyVillager.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyVindicator.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyVindicator.java
@@ -202,7 +202,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyWitherSkeleton.java
@@ -156,7 +156,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyZombie.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyZombie.java
@@ -197,7 +197,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyZombifiedPiglin.java
@@ -182,7 +182,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/EntityMyPet.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/EntityMyPet.java
@@ -684,6 +684,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -695,6 +698,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyAllay.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyAllay.java
@@ -172,7 +172,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyDrowned.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyDrowned.java
@@ -199,7 +199,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyEvoker.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyEvoker.java
@@ -174,7 +174,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyFox.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyFox.java
@@ -202,7 +202,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyGiant.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyGiant.java
@@ -158,7 +158,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyHorse.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyHorse.java
@@ -279,7 +279,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyHusk.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyHusk.java
@@ -197,7 +197,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyIllusioner.java
@@ -197,7 +197,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPhantom.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPiglin.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPiglin.java
@@ -186,7 +186,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPiglinBrute.java
@@ -170,7 +170,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPillager.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyPillager.java
@@ -198,7 +198,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMySkeleton.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMySkeleton.java
@@ -176,7 +176,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyStray.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyStray.java
@@ -156,7 +156,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyVex.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyVex.java
@@ -182,7 +182,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyVillager.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyVindicator.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyVindicator.java
@@ -202,7 +202,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyWitherSkeleton.java
@@ -156,7 +156,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyZombie.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyZombie.java
@@ -197,7 +197,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyZombifiedPiglin.java
@@ -182,7 +182,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/EntityMyPet.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/EntityMyPet.java
@@ -684,6 +684,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -695,6 +698,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyAllay.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyAllay.java
@@ -172,7 +172,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyDrowned.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyDrowned.java
@@ -199,7 +199,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyEvoker.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyEvoker.java
@@ -174,7 +174,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyFox.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyFox.java
@@ -202,7 +202,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyGiant.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyGiant.java
@@ -158,7 +158,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyHorse.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyHorse.java
@@ -279,7 +279,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyHusk.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyHusk.java
@@ -197,7 +197,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyIllusioner.java
@@ -197,7 +197,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPhantom.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPiglin.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPiglin.java
@@ -186,7 +186,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPiglinBrute.java
@@ -170,7 +170,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPillager.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyPillager.java
@@ -198,7 +198,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMySkeleton.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMySkeleton.java
@@ -176,7 +176,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyStray.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyStray.java
@@ -156,7 +156,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyVex.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyVex.java
@@ -181,7 +181,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyVillager.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyVindicator.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyVindicator.java
@@ -202,7 +202,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyWitherSkeleton.java
@@ -156,7 +156,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyZombie.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyZombie.java
@@ -197,7 +197,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyZombifiedPiglin.java
@@ -182,7 +182,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/EntityMyPet.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/EntityMyPet.java
@@ -692,6 +692,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -703,6 +706,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyAllay.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyAllay.java
@@ -172,7 +172,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyDrowned.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyDrowned.java
@@ -199,7 +199,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyEvoker.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyEvoker.java
@@ -174,7 +174,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyFox.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyFox.java
@@ -202,7 +202,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyGiant.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyGiant.java
@@ -158,7 +158,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyHorse.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyHorse.java
@@ -279,7 +279,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyHusk.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyHusk.java
@@ -197,7 +197,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyIllusioner.java
@@ -197,7 +197,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPhantom.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPhantom.java
@@ -69,7 +69,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPiglin.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPiglin.java
@@ -186,7 +186,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPiglinBrute.java
@@ -170,7 +170,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPillager.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyPillager.java
@@ -198,7 +198,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMySkeleton.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMySkeleton.java
@@ -176,7 +176,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyStray.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyStray.java
@@ -156,7 +156,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyVex.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyVex.java
@@ -181,7 +181,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyVillager.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyVindicator.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyVindicator.java
@@ -202,7 +202,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyWitherSkeleton.java
@@ -156,7 +156,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyZombie.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyZombie.java
@@ -197,7 +197,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyZombifiedPiglin.java
@@ -182,7 +182,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/EntityMyPet.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/EntityMyPet.java
@@ -698,6 +698,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -709,6 +712,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyAllay.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyAllay.java
@@ -163,7 +163,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyDrowned.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyDrowned.java
@@ -190,7 +190,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyEvoker.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyEvoker.java
@@ -165,7 +165,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyFox.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyFox.java
@@ -193,7 +193,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyGiant.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyGiant.java
@@ -149,7 +149,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyHorse.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyHorse.java
@@ -270,7 +270,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyHusk.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyHusk.java
@@ -188,7 +188,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyIllusioner.java
@@ -188,7 +188,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPhantom.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPiglin.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPiglin.java
@@ -177,7 +177,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPiglinBrute.java
@@ -161,7 +161,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPillager.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyPillager.java
@@ -189,7 +189,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMySkeleton.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMySkeleton.java
@@ -167,7 +167,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyStray.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyStray.java
@@ -147,7 +147,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyVex.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyVex.java
@@ -172,7 +172,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyVillager.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyVillager.java
@@ -170,7 +170,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyVindicator.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyVindicator.java
@@ -193,7 +193,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyWitherSkeleton.java
@@ -147,7 +147,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyZombie.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyZombie.java
@@ -187,7 +187,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyZombieVillager.java
@@ -202,7 +202,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyZombifiedPiglin.java
@@ -173,7 +173,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/EntityMyPet.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/EntityMyPet.java
@@ -148,6 +148,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 		try {
 			this.replaceCraftAttributes();
+			this.replaceAttributes();
 			this.setBukkitEntity();
 
 			this.myPet = myPet;
@@ -168,6 +169,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	protected void replaceAttributes() {
+		// The LivingEntity super constructor builds its `attributes` field from
+		// DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+		// types -> an AttributeMap with a null supplier. Most paths go through the
+		// overridden getAttributes(), but vanilla equipment sync reads the field
+		// directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+		// an item carrying attribute modifiers. Point the field at our safe map.
+		Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+		ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
 	}
 
 	protected void replaceCraftAttributes() {

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/EntityMyPet.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/EntityMyPet.java
@@ -710,6 +710,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -721,6 +724,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyAllay.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyAllay.java
@@ -163,7 +163,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyDrowned.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyDrowned.java
@@ -189,7 +189,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyEvoker.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyEvoker.java
@@ -165,7 +165,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyFox.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyFox.java
@@ -193,7 +193,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyGiant.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyGiant.java
@@ -148,7 +148,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyHorse.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyHorse.java
@@ -270,7 +270,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyHusk.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyHusk.java
@@ -187,7 +187,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyIllusioner.java
@@ -187,7 +187,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPhantom.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPiglin.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPiglin.java
@@ -176,7 +176,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPiglinBrute.java
@@ -160,7 +160,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPillager.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyPillager.java
@@ -188,7 +188,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMySkeleton.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMySkeleton.java
@@ -172,7 +172,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyStray.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyStray.java
@@ -146,7 +146,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyVex.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyVex.java
@@ -171,7 +171,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyVillager.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyVillager.java
@@ -170,7 +170,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyVindicator.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyVindicator.java
@@ -192,7 +192,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyWitherSkeleton.java
@@ -146,7 +146,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyZombie.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyZombie.java
@@ -186,7 +186,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyZombieVillager.java
@@ -201,7 +201,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyZombifiedPiglin.java
@@ -172,7 +172,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getFilterFlag());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/EntityMyPet.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/EntityMyPet.java
@@ -148,6 +148,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 		try {
 			this.replaceCraftAttributes();
+			this.replaceAttributes();
 			this.setBukkitEntity();
 
 			this.myPet = myPet;
@@ -168,6 +169,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	protected void replaceAttributes() {
+		// The LivingEntity super constructor builds its `attributes` field from
+		// DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+		// types -> an AttributeMap with a null supplier. Most paths go through the
+		// overridden getAttributes(), but vanilla equipment sync reads the field
+		// directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+		// an item carrying attribute modifiers. Point the field at our safe map.
+		Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+		ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
 	}
 
 	protected void replaceCraftAttributes() {

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/EntityMyPet.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/EntityMyPet.java
@@ -710,6 +710,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -721,6 +724,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyAllay.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyAllay.java
@@ -163,7 +163,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyDrowned.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyDrowned.java
@@ -189,7 +189,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyEvoker.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyEvoker.java
@@ -165,7 +165,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyFox.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyFox.java
@@ -193,7 +193,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyGiant.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyGiant.java
@@ -148,7 +148,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyHorse.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyHorse.java
@@ -270,7 +270,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyHusk.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyHusk.java
@@ -187,7 +187,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyIllusioner.java
@@ -187,7 +187,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPhantom.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPiglin.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPiglin.java
@@ -176,7 +176,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPiglinBrute.java
@@ -160,7 +160,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPillager.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyPillager.java
@@ -188,7 +188,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMySkeleton.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMySkeleton.java
@@ -172,7 +172,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyStray.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyStray.java
@@ -146,7 +146,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyVex.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyVex.java
@@ -171,7 +171,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyVillager.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyVillager.java
@@ -170,7 +170,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyVindicator.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyVindicator.java
@@ -192,7 +192,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyWitherSkeleton.java
@@ -146,7 +146,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyZombie.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyZombie.java
@@ -186,7 +186,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyZombieVillager.java
@@ -201,7 +201,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyZombifiedPiglin.java
@@ -172,7 +172,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/EntityMyPet.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/EntityMyPet.java
@@ -148,6 +148,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 		try {
 			this.replaceCraftAttributes();
+			this.replaceAttributes();
 			this.setBukkitEntity();
 
 			this.myPet = myPet;
@@ -168,6 +169,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	protected void replaceAttributes() {
+		// The LivingEntity super constructor builds its `attributes` field from
+		// DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+		// types -> an AttributeMap with a null supplier. Most paths go through the
+		// overridden getAttributes(), but vanilla equipment sync reads the field
+		// directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+		// an item carrying attribute modifiers. Point the field at our safe map.
+		Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+		ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
 	}
 
 	protected void replaceCraftAttributes() {

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/EntityMyPet.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/EntityMyPet.java
@@ -711,6 +711,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -722,6 +725,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyAllay.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyAllay.java
@@ -163,7 +163,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyDrowned.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyDrowned.java
@@ -189,7 +189,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyEvoker.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyEvoker.java
@@ -165,7 +165,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyFox.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyFox.java
@@ -193,7 +193,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyGiant.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyGiant.java
@@ -148,7 +148,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyHorse.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyHorse.java
@@ -270,7 +270,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyHusk.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyHusk.java
@@ -187,7 +187,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyIllusioner.java
@@ -187,7 +187,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPhantom.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPiglin.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPiglin.java
@@ -176,7 +176,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPiglinBrute.java
@@ -160,7 +160,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPillager.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyPillager.java
@@ -188,7 +188,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMySkeleton.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMySkeleton.java
@@ -172,7 +172,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyStray.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyStray.java
@@ -146,7 +146,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyVex.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyVex.java
@@ -171,7 +171,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyVillager.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyVillager.java
@@ -170,7 +170,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyVindicator.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyVindicator.java
@@ -192,7 +192,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyWitherSkeleton.java
@@ -146,7 +146,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyZombie.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyZombie.java
@@ -186,7 +186,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyZombieVillager.java
@@ -201,7 +201,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyZombifiedPiglin.java
@@ -172,7 +172,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/EntityMyPet.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/EntityMyPet.java
@@ -154,6 +154,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 		try {
 			this.replaceCraftAttributes();
+			this.replaceAttributes();
 			this.setBukkitEntity();
 
 			this.myPet = myPet;
@@ -174,6 +175,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	protected void replaceAttributes() {
+		// The LivingEntity super constructor builds its `attributes` field from
+		// DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+		// types -> an AttributeMap with a null supplier. Most paths go through the
+		// overridden getAttributes(), but vanilla equipment sync reads the field
+		// directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+		// an item carrying attribute modifiers. Point the field at our safe map.
+		Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+		ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
 	}
 
 	protected void replaceCraftAttributes() {

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/EntityMyPet.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/EntityMyPet.java
@@ -717,6 +717,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
 	@Override
 	public float getHealth() {
+		if (myPet == null) {
+			return super.getHealth();
+		}
 		double health = super.getHealth();
 		double maxHealth = myPet.getMaxHealth();
 		if (health > maxHealth) {
@@ -728,6 +731,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyAllay.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyAllay.java
@@ -163,7 +163,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyDrowned.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyDrowned.java
@@ -187,7 +187,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyEvoker.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyEvoker.java
@@ -165,7 +165,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyFox.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyFox.java
@@ -194,7 +194,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyGiant.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyGiant.java
@@ -148,7 +148,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyHorse.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyHorse.java
@@ -270,7 +270,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyHusk.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyHusk.java
@@ -187,7 +187,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyIllusioner.java
@@ -187,7 +187,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPhantom.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPiglin.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPiglin.java
@@ -176,7 +176,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPiglinBrute.java
@@ -160,7 +160,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPillager.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyPillager.java
@@ -188,7 +188,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMySkeleton.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMySkeleton.java
@@ -172,7 +172,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyStray.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyStray.java
@@ -146,7 +146,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyVex.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyVex.java
@@ -171,7 +171,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyVillager.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyVindicator.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyVindicator.java
@@ -192,7 +192,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyWitherSkeleton.java
@@ -146,7 +146,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyZombie.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyZombie.java
@@ -186,7 +186,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyZombifiedPiglin.java
@@ -172,7 +172,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/EntityMyPet.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/EntityMyPet.java
@@ -152,6 +152,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
         try {
             this.replaceCraftAttributes();
+            this.replaceAttributes();
             this.setBukkitEntity();
             this.myPet = myPet;
             this.isMyPet = true;
@@ -173,6 +174,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    protected void replaceAttributes() {
+        // The LivingEntity super constructor builds its `attributes` field from
+        // DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+        // types -> an AttributeMap with a null supplier. Most paths go through the
+        // overridden getAttributes(), but vanilla equipment sync reads the field
+        // directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+        // an item carrying attribute modifiers. Point the field at our safe map.
+        Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+        ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
     }
 
     protected void replaceCraftAttributes() {

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/EntityMyPet.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/EntityMyPet.java
@@ -741,6 +741,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public float getHealth() {
+        if (myPet == null) {
+            return super.getHealth();
+        }
         double health = super.getHealth();
         double maxHealth = myPet.getMaxHealth();
         if (health > maxHealth) {
@@ -752,6 +755,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyAllay.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyAllay.java
@@ -163,7 +163,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyDrowned.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyDrowned.java
@@ -187,7 +187,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyEvoker.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyEvoker.java
@@ -165,7 +165,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyFox.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyFox.java
@@ -194,7 +194,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyGiant.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyGiant.java
@@ -148,7 +148,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyHorse.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyHorse.java
@@ -270,7 +270,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyHusk.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyHusk.java
@@ -187,7 +187,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyIllusioner.java
@@ -187,7 +187,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPhantom.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPiglin.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPiglin.java
@@ -176,7 +176,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPiglinBrute.java
@@ -160,7 +160,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPillager.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyPillager.java
@@ -188,7 +188,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMySkeleton.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMySkeleton.java
@@ -172,7 +172,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyStray.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyStray.java
@@ -146,7 +146,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyVex.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyVex.java
@@ -171,7 +171,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyVillager.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyVillager.java
@@ -179,7 +179,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyVindicator.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyVindicator.java
@@ -192,7 +192,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyWitherSkeleton.java
@@ -146,7 +146,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyZombie.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyZombie.java
@@ -186,7 +186,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyZombieVillager.java
@@ -211,7 +211,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyZombifiedPiglin.java
@@ -172,7 +172,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/EntityMyPet.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/EntityMyPet.java
@@ -737,6 +737,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public float getHealth() {
+        if (myPet == null) {
+            return super.getHealth();
+        }
         double health = super.getHealth();
         double maxHealth = myPet.getMaxHealth();
         if (health > maxHealth) {
@@ -748,6 +751,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/EntityMyPet.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/EntityMyPet.java
@@ -148,6 +148,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
         try {
             this.replaceCraftAttributes();
+            this.replaceAttributes();
             this.setBukkitEntity();
             this.myPet = myPet;
             this.isMyPet = true;
@@ -169,6 +170,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    protected void replaceAttributes() {
+        // The LivingEntity super constructor builds its `attributes` field from
+        // DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+        // types -> an AttributeMap with a null supplier. Most paths go through the
+        // overridden getAttributes(), but vanilla equipment sync reads the field
+        // directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+        // an item carrying attribute modifiers. Point the field at our safe map.
+        Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+        ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
     }
 
     protected void replaceCraftAttributes() {

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyAllay.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyAllay.java
@@ -165,7 +165,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyDrowned.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyDrowned.java
@@ -189,7 +189,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyEvoker.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyEvoker.java
@@ -167,7 +167,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyFox.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyFox.java
@@ -196,7 +196,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyGiant.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyGiant.java
@@ -150,7 +150,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyHorse.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyHorse.java
@@ -272,7 +272,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyHusk.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyHusk.java
@@ -189,7 +189,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyIllusioner.java
@@ -189,7 +189,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPhantom.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPiglin.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPiglin.java
@@ -178,7 +178,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPiglinBrute.java
@@ -162,7 +162,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPillager.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyPillager.java
@@ -190,7 +190,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMySkeleton.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMySkeleton.java
@@ -174,7 +174,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyStray.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyStray.java
@@ -148,7 +148,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyVex.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyVex.java
@@ -173,7 +173,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyVillager.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyVillager.java
@@ -181,7 +181,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyVindicator.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyVindicator.java
@@ -194,7 +194,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyWitherSkeleton.java
@@ -148,7 +148,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyZombie.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyZombie.java
@@ -188,7 +188,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyZombieVillager.java
@@ -213,7 +213,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyZombifiedPiglin.java
@@ -174,7 +174,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/EntityMyPet.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/EntityMyPet.java
@@ -737,6 +737,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public float getHealth() {
+        if (myPet == null) {
+            return super.getHealth();
+        }
         double health = super.getHealth();
         double maxHealth = myPet.getMaxHealth();
         if (health > maxHealth) {
@@ -748,6 +751,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/EntityMyPet.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/EntityMyPet.java
@@ -148,6 +148,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
         try {
             this.replaceCraftAttributes();
+            this.replaceAttributes();
             this.setBukkitEntity();
             this.myPet = myPet;
             this.isMyPet = true;
@@ -169,6 +170,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    protected void replaceAttributes() {
+        // The LivingEntity super constructor builds its `attributes` field from
+        // DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+        // types -> an AttributeMap with a null supplier. Most paths go through the
+        // overridden getAttributes(), but vanilla equipment sync reads the field
+        // directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+        // an item carrying attribute modifiers. Point the field at our safe map.
+        Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+        ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
     }
 
     protected void replaceCraftAttributes() {

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyAllay.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyAllay.java
@@ -164,7 +164,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyDrowned.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyDrowned.java
@@ -188,7 +188,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyEvoker.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyEvoker.java
@@ -166,7 +166,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyFox.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyFox.java
@@ -195,7 +195,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyGiant.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyGiant.java
@@ -149,7 +149,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyHorse.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyHorse.java
@@ -271,7 +271,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyHusk.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyHusk.java
@@ -188,7 +188,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyIllusioner.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyIllusioner.java
@@ -188,7 +188,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPhantom.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPiglin.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPiglin.java
@@ -177,7 +177,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPiglinBrute.java
@@ -161,7 +161,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPillager.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyPillager.java
@@ -189,7 +189,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMySkeleton.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMySkeleton.java
@@ -173,7 +173,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyStray.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyStray.java
@@ -147,7 +147,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyVex.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyVex.java
@@ -173,7 +173,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyVillager.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyVillager.java
@@ -180,7 +180,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyVindicator.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyVindicator.java
@@ -193,7 +193,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyWitherSkeleton.java
@@ -147,7 +147,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyZombie.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyZombie.java
@@ -187,7 +187,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyZombieVillager.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyZombieVillager.java
@@ -212,7 +212,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyZombifiedPiglin.java
@@ -173,7 +173,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v1_8_R3/src/main/java/de/Keyle/MyPet/compat/v1_8_R3/entity/EntityMyPet.java
+++ b/nms/v1_8_R3/src/main/java/de/Keyle/MyPet/compat/v1_8_R3/entity/EntityMyPet.java
@@ -621,6 +621,10 @@ public abstract class EntityMyPet extends EntityCreature implements IAnimal, MyP
     }
 
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttributeInstance(GenericAttributes.maxHealth).getValue() != maxHealth;

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/EntityMyPet.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/EntityMyPet.java
@@ -148,6 +148,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
         try {
             this.replaceCraftAttributes();
+            this.replaceAttributes();
             this.setBukkitEntity();
             this.myPet = myPet;
             this.isMyPet = true;
@@ -175,6 +176,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
         Field craftAttributesField = ReflectionUtil.getField(LivingEntity.class, "craftAttributes");
         CraftAttributeMap craftAttributes = new CraftAttributeMap(this.getAttributes());
         ReflectionUtil.setFinalFieldValue(craftAttributesField, this, craftAttributes);
+    }
+
+    protected void replaceAttributes() {
+        // The LivingEntity super constructor builds its `attributes` field from
+        // DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+        // types -> an AttributeMap with a null supplier. Most paths go through the
+        // overridden getAttributes(), but vanilla's equipment sync reads the field
+        // directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+        // an item carrying attribute modifiers. Point the field at our safe map.
+        Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+        ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
     }
 
     protected void initAttributes() {

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/EntityMyPet.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/EntityMyPet.java
@@ -737,6 +737,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public float getHealth() {
+        if (myPet == null) {
+            return super.getHealth();
+        }
         double health = super.getHealth();
         double maxHealth = myPet.getMaxHealth();
         if (health > maxHealth) {
@@ -748,6 +751,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyAllay.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyAllay.java
@@ -164,7 +164,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyDrowned.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyDrowned.java
@@ -188,7 +188,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyEvoker.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyEvoker.java
@@ -166,7 +166,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyFox.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyFox.java
@@ -197,7 +197,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyGiant.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyGiant.java
@@ -149,7 +149,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyHorse.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyHorse.java
@@ -273,7 +273,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyHusk.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyHusk.java
@@ -188,7 +188,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyIllusioner.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyIllusioner.java
@@ -188,7 +188,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPhantom.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPiglin.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPiglin.java
@@ -177,7 +177,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPiglinBrute.java
@@ -161,7 +161,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPillager.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyPillager.java
@@ -189,7 +189,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMySkeleton.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMySkeleton.java
@@ -173,7 +173,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyStray.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyStray.java
@@ -147,7 +147,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyVex.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyVex.java
@@ -173,7 +173,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyVillager.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyVillager.java
@@ -182,7 +182,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyVindicator.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyVindicator.java
@@ -193,7 +193,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyWitherSkeleton.java
@@ -147,7 +147,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyZombie.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyZombie.java
@@ -187,7 +187,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyZombieVillager.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyZombieVillager.java
@@ -212,7 +212,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyZombifiedPiglin.java
@@ -173,7 +173,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/EntityMyPet.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/EntityMyPet.java
@@ -148,6 +148,7 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
         try {
             this.replaceCraftAttributes();
+            this.replaceAttributes();
             this.setBukkitEntity();
             this.myPet = myPet;
             this.isMyPet = true;
@@ -175,6 +176,17 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
         Field craftAttributesField = ReflectionUtil.getField(LivingEntity.class, "craftAttributes");
         CraftAttributeMap craftAttributes = new CraftAttributeMap(this.getAttributes());
         ReflectionUtil.setFinalFieldValue(craftAttributesField, this, craftAttributes);
+    }
+
+    protected void replaceAttributes() {
+        // The LivingEntity super constructor builds its `attributes` field from
+        // DefaultAttributes.getSupplier(mypet_*), which is null for our custom entity
+        // types -> an AttributeMap with a null supplier. Most paths go through the
+        // overridden getAttributes(), but vanilla's equipment sync reads the field
+        // directly (LivingEntity.collectEquipmentChanges), which NPEs when a pet wears
+        // an item carrying attribute modifiers. Point the field at our safe map.
+        Field attributesField = ReflectionUtil.getField(LivingEntity.class, "attributes");
+        ReflectionUtil.setFinalFieldValue(attributesField, this, this.getAttributes());
     }
 
     protected void initAttributes() {

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/EntityMyPet.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/EntityMyPet.java
@@ -737,6 +737,9 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public float getHealth() {
+        if (myPet == null) {
+            return super.getHealth();
+        }
         double health = super.getHealth();
         double maxHealth = myPet.getMaxHealth();
         if (health > maxHealth) {
@@ -748,6 +751,10 @@ public abstract class EntityMyPet extends PathfinderMob implements MyPetMinecraf
 
     @Override
     public void setHealth(float f) {
+        if (myPet == null) {
+            super.setHealth(f);
+            return;
+        }
         double maxHealth = myPet.getMaxHealth();
 
         boolean silent = this.getAttribute(Attributes.MAX_HEALTH).getValue() != maxHealth;

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/ai/movement/FollowOwner.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/ai/movement/FollowOwner.java
@@ -527,6 +527,17 @@ public class FollowOwner implements AIGoal {
         return owner.isInWater() && !canPetSwim() && !flyingPet;
     }
 
+    // Some Paper builds remap Abilities#getWalkingSpeed to a narrower access level than the
+    // compile-time API declares, so the call throws IllegalAccessError at runtime. Fall back to
+    // the vanilla default speed rather than crashing the AI goal.
+    private float getWalkingSpeed(Player player) {
+        try {
+            return player.getAbilities().getWalkingSpeed();
+        } catch (LinkageError e) {
+            return NORMAL_WALK_SPEED;
+        }
+    }
+
     /** Tracks whether the Pet is currently performing surface swimming toward the owner. */
     private boolean surfaceSwimmingToOwner = false;
 
@@ -723,7 +734,7 @@ public class FollowOwner implements AIGoal {
                 boolean swimmingPet = isSwimmingPet();
                 {
                     Vec3 vel = this.petEntity.getDeltaMovement();
-                    float ownerSpeed = owner.getAbilities().getWalkingSpeed();
+                    float ownerSpeed = getWalkingSpeed(owner);
                     // Cap speed multiplier - Pets can't handle extreme speeds
                     // At speed 5 (0.5 walkspeed), raw multiplier would be 5.0, cap at MAX_SPEED_MULTIPLIER
                     double rawSpeedMultiplier = Math.max(1.0, ownerSpeed / NORMAL_WALK_SPEED);
@@ -918,7 +929,7 @@ public class FollowOwner implements AIGoal {
      * @param distance the current distance from Pet to owner in blocks
      */
     private void applyWalkSpeed(double distance) {
-        float baseWalkSpeed = owner.getAbilities().getWalkingSpeed();
+        float baseWalkSpeed = getWalkingSpeed(owner);
         float walkSpeed = baseWalkSpeed;
 
         // When close to owner, use cruise speed to match their pace

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyAllay.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyAllay.java
@@ -165,7 +165,7 @@ public class EntityMyAllay extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyChicken.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyChicken.java
@@ -122,10 +122,23 @@ public class EntityMyChicken extends EntityMyPet {
 
 		if (Configuration.MyPet.Chicken.CAN_LAY_EGGS && canUseItem() && --nextEggTimer <= 0) {
 			this.makeSound("entity.chicken.egg", 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);
-			this.forceDrops = true; // CraftBukkit
+			setForceDrops(true);
 			this.spawnAtLocation(this.level().getMinecraftWorld(), Items.EGG);
-			this.forceDrops = false; // CraftBukkit
+			setForceDrops(false);
 			nextEggTimer = this.random.nextInt(6000) + 6000;
+		}
+	}
+
+	// CraftBukkit's forceDrops flag makes spawnAtLocation() spawn a real item instead of
+	// funneling it into the death-loot capture list. Some server builds don't expose this
+	// field at runtime even though it's present in the API MyPet compiles against, throwing
+	// NoSuchFieldError. Swallow that instead of crashing every egg-lay tick; worst case on
+	// those builds is a lost egg if the capture list happens to be active, not a broken pet.
+	private void setForceDrops(boolean value) {
+		try {
+			this.forceDrops = value;
+		} catch (LinkageError e) {
+			// field not present on this server build - ignore
 		}
 	}
 

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyDrowned.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyDrowned.java
@@ -189,7 +189,7 @@ public class EntityMyDrowned extends EntityMyAquaticPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyEvoker.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyEvoker.java
@@ -167,7 +167,7 @@ public class EntityMyEvoker extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyFox.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyFox.java
@@ -198,7 +198,7 @@ public class EntityMyFox extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyGiant.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyGiant.java
@@ -150,7 +150,7 @@ public class EntityMyGiant extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyHorse.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyHorse.java
@@ -274,7 +274,7 @@ public class EntityMyHorse extends EntityMyPet{
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (slot == EquipmentSlot.Chestplate && getMyPet().getArmor() != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getArmor());

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyHusk.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyHusk.java
@@ -189,7 +189,7 @@ public class EntityMyHusk extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyIllusioner.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyIllusioner.java
@@ -189,7 +189,7 @@ public class EntityMyIllusioner extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPhantom.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPhantom.java
@@ -70,7 +70,7 @@ public class EntityMyPhantom extends EntityMyFlyingPet {
 		getEntityData().set(SIZE_WATCHER, size);
 		this.refreshDimensions();
 		if (petPathfinderSelector != null && petPathfinderSelector.hasGoal("MeleeAttack")) {
-			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.1F, 3 + (getMyPet().getSize() * 0.2), 20));
+			petPathfinderSelector.replaceGoal("MeleeAttack", new MeleeAttack(this, 0.7F, 3 + (getMyPet().getSize() * 0.2), 20));
 		}
 	}
 

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPiglin.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPiglin.java
@@ -178,7 +178,7 @@ public class EntityMyPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPiglinBrute.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPiglinBrute.java
@@ -162,7 +162,7 @@ public class EntityMyPiglinBrute extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPillager.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyPillager.java
@@ -190,7 +190,7 @@ public class EntityMyPillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMySkeleton.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMySkeleton.java
@@ -174,7 +174,7 @@ public class EntityMySkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyStray.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyStray.java
@@ -148,7 +148,7 @@ public class EntityMyStray extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyVex.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyVex.java
@@ -174,7 +174,7 @@ public class EntityMyVex extends EntityMyFlyingPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyVillager.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyVillager.java
@@ -183,7 +183,7 @@ public class EntityMyVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyVindicator.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyVindicator.java
@@ -194,7 +194,7 @@ public class EntityMyVindicator extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyWitherSkeleton.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyWitherSkeleton.java
@@ -148,7 +148,7 @@ public class EntityMyWitherSkeleton extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyZombie.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyZombie.java
@@ -188,7 +188,7 @@ public class EntityMyZombie extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyZombieVillager.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyZombieVillager.java
@@ -213,7 +213,7 @@ public class EntityMyZombieVillager extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyZombifiedPiglin.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyZombifiedPiglin.java
@@ -174,7 +174,7 @@ public class EntityMyZombifiedPiglin extends EntityMyPet {
 
 	@Override
 	public ItemStack getItemBySlot(net.minecraft.world.entity.EquipmentSlot vanillaSlot) {
-		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2)) {
+		if (MyPetApi.getPlatformHelper().doStackWalking(ServerEntity.class, 2) && getMyPet() != null) {
 			EquipmentSlot slot = EquipmentSlot.getSlotById(vanillaSlot.getId());
 			if (getMyPet().getEquipment(slot) != null) {
 				return CraftItemStack.asNMSCopy(getMyPet().getEquipment(slot));

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
     compileOnly("com.github.Angeschossen:LandsAPI:4.5.2.0")
     compileOnly("de.keyle:mypet-premium-apis:1.0-SNAPSHOT")
 
-    compileOnly("org.bstats:bstats-bukkit:1.7")
+    compileOnly("org.bstats:bstats-bukkit:3.1.0")
     compileOnly("org.mongodb:mongodb-driver:3.12.11")
     compileOnly("de.keyle:knbt:0.0.6")
 

--- a/plugin/src/main/java/de/Keyle/MyPet/MyPetPlugin.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/MyPetPlugin.java
@@ -195,6 +195,8 @@ public final class MyPetPlugin extends JavaPlugin implements de.Keyle.MyPet.api.
         String updateStatus = updater.update();
         printSplashScreen(updateStatus);
 
+        getLogger().warning("MyPet 3 has reached end of life and will no longer receive substantive updates. If your server version supports it, please migrate to MyPet v4: https://builtbybit.com/resources/mypet-4.115339/");
+
         if (compatUtil.getInternalVersion() == null || !MyPetVersion.isValidBukkitPacket(compatUtil.getInternalVersion())) {
             getLogger().warning("This version of MyPet is not compatible with \"" + compatUtil.getInternalVersion() + " on " + compatUtil.getMinecraftVersion() + "\". Is MyPet up to date?");
             updater.waitForDownload();

--- a/plugin/src/main/java/de/Keyle/MyPet/MyPetPlugin.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/MyPetPlugin.java
@@ -66,6 +66,9 @@ import de.Keyle.MyPet.util.sentry.SentryErrorReporter;
 import de.Keyle.MyPet.util.shop.ShopManager;
 import de.Keyle.MyPet.util.translation.VanillaTranslationLoader;
 import org.bstats.bukkit.Metrics;
+import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.SimplePie;
+import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -429,11 +432,12 @@ public final class MyPetPlugin extends JavaPlugin implements de.Keyle.MyPet.api.
 
         // init Metrics
         try {
-            Metrics metrics = new Metrics(this, 778);
-            if (metrics.isEnabled() && !MyPetVersion.isLocalBuild()) {
-                metrics.addCustomChart(new Metrics.SingleLineChart("active_pets", () -> myPetManager.countActiveMyPets()));
-                metrics.addCustomChart(new Metrics.SimplePie("build", MyPetVersion::getBuild));
-                metrics.addCustomChart(new Metrics.SimplePie("update_mode", () -> {
+            // Don't construct Metrics on local builds
+            if (!MyPetVersion.isLocalBuild()) {
+                Metrics metrics = new Metrics(this, 778);
+                metrics.addCustomChart(new SingleLineChart("active_pets", () -> myPetManager.countActiveMyPets()));
+                metrics.addCustomChart(new SimplePie("build", MyPetVersion::getBuild));
+                metrics.addCustomChart(new SimplePie("update_mode", () -> {
                     String mode = "Disabled";
                     if (Configuration.Update.CHECK) {
                         mode = "Check";
@@ -444,7 +448,7 @@ public final class MyPetPlugin extends JavaPlugin implements de.Keyle.MyPet.api.
                     return mode;
                 }
                 ));
-                metrics.addCustomChart(new Metrics.AdvancedPie("hooks", () -> {
+                metrics.addCustomChart(new AdvancedPie("hooks", () -> {
                     Map<String, Integer> activatedHooks = new HashMap<>();
                     for (PluginHook hook : MyPetApi.getPluginHookManager().getHooks()) {
                         activatedHooks.put(hook.getPluginName(), 1);
@@ -452,7 +456,7 @@ public final class MyPetPlugin extends JavaPlugin implements de.Keyle.MyPet.api.
                     return activatedHooks;
                 }
                 ));
-                metrics.addCustomChart(new Metrics.AdvancedPie("pet_types", () -> {
+                metrics.addCustomChart(new AdvancedPie("pet_types", () -> {
                     Map<String, Integer> petTypes = new HashMap<>();
                     for (MyPet pet : myPetManager.getAllActiveMyPets()) {
                         petTypes.merge(pet.getPetType().name(), 1, Integer::sum);
@@ -460,7 +464,7 @@ public final class MyPetPlugin extends JavaPlugin implements de.Keyle.MyPet.api.
                     return petTypes;
                 }
                 ));
-                metrics.addCustomChart(new Metrics.SimplePie("database_type", () -> {
+                metrics.addCustomChart(new SimplePie("database_type", () -> {
                     String type = null;
                     if (Configuration.Repository.REPOSITORY_TYPE.equalsIgnoreCase("SQLite")) {
                         type = "SQLite";
@@ -471,7 +475,7 @@ public final class MyPetPlugin extends JavaPlugin implements de.Keyle.MyPet.api.
                     }
                     return type;
                 }));
-                metrics.addCustomChart(new Metrics.AdvancedPie("active_skills", () -> {
+                metrics.addCustomChart(new AdvancedPie("active_skills", () -> {
                     Map<String, Integer> skillCounts = new HashMap<>();
                     for (MyPet pet : myPetManager.getAllActiveMyPets()) {
                         for (Skill skill : pet.getSkills().all()) {

--- a/plugin/src/main/java/de/Keyle/MyPet/listeners/CreakingHeartListener.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/listeners/CreakingHeartListener.java
@@ -114,7 +114,7 @@ public class CreakingHeartListener implements Listener {
 
         // Check leash item in main hand
         ItemStack leashItem = player.getInventory().getItemInMainHand();
-        if (!neededLeashItem.compare(leashItem)) {
+        if (neededLeashItem != null && !neededLeashItem.compare(leashItem)) {
             return;
         }
 
@@ -292,6 +292,9 @@ public class CreakingHeartListener implements Listener {
 
         // Check leash item
         ConfigItem neededLeashItem = MyPetApi.getMyPetInfo().getLeashItem(petType);
+        if (neededLeashItem == null) {
+            return;
+        }
         ItemStack leashItem = player.getInventory().getItemInMainHand();
         String itemName = neededLeashItem.getItem().getType().name().toLowerCase().replace("_", " ");
         if (!neededLeashItem.compare(leashItem)) {

--- a/plugin/src/main/java/de/Keyle/MyPet/listeners/EntityListener.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/listeners/EntityListener.java
@@ -268,7 +268,7 @@ public class EntityListener implements Listener {
                         return;
                     }
                     boolean usedArrow = false;
-                    if (!neededLeashItem.compare(leashItem)) {
+                    if (neededLeashItem != null && !neededLeashItem.compare(leashItem)) {
                         if (leashItemArrow == null || !neededLeashItem.compare(leashItemArrow)) {
                             return;
                         } else {
@@ -439,7 +439,8 @@ public class EntityListener implements Listener {
                 if (event.getDamage() == 0) {
                     return;
                 } else if (target instanceof MyPetBukkitEntity) {
-                    if (MyPetApi.getMyPetInfo().getLeashItem(((MyPetBukkitEntity) target).getPetType()).compare(player.getItemInHand())) {
+                    ConfigItem neededLeashItem = MyPetApi.getMyPetInfo().getLeashItem(((MyPetBukkitEntity) target).getPetType());
+                    if (neededLeashItem == null || neededLeashItem.compare(player.getItemInHand())) {
                         return;
                     }
                 }

--- a/plugin/src/main/java/de/Keyle/MyPet/listeners/MyPetEntityListener.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/listeners/MyPetEntityListener.java
@@ -178,7 +178,8 @@ public class MyPetEntityListener implements Listener {
                 } else {
                     leashItem = damager.getItemInHand();
                 }
-                if (MyPetApi.getMyPetInfo().getLeashItem(myPet.getPetType()).compare(leashItem)) {
+                ConfigItem neededLeashItem = MyPetApi.getMyPetInfo().getLeashItem(myPet.getPetType());
+                if (neededLeashItem == null || neededLeashItem.compare(leashItem)) {
                     boolean infoShown = false;
                     if (CommandInfo.canSee(PetInfoDisplay.Name.adminOnly, damager, myPet)) {
                         damager.sendMessage(ChatColor.AQUA + myPet.getPetName() + ChatColor.RESET + ":");

--- a/plugin/src/main/java/de/Keyle/MyPet/listeners/MyPetEntityListener.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/listeners/MyPetEntityListener.java
@@ -26,7 +26,6 @@ import de.Keyle.MyPet.api.Util;
 import de.Keyle.MyPet.api.WorldGroup;
 import de.Keyle.MyPet.api.entity.*;
 import de.Keyle.MyPet.api.entity.MyPet.PetState;
-import de.Keyle.MyPet.api.entity.ai.target.TargetPriority;
 import de.Keyle.MyPet.api.entity.skill.ranged.CraftMyPetProjectile;
 import de.Keyle.MyPet.api.entity.skill.ranged.EntityMyPetProjectile;
 import de.Keyle.MyPet.api.event.MyPetDamageEvent;
@@ -299,14 +298,20 @@ public class MyPetEntityListener implements Listener {
                 EntityMyPetProjectile projectile = ((CraftMyPetProjectile) event.getDamager()).getMyPetProjectile();
 
                 if (projectile != null && projectile.getShooter() != null) {
-                    if (myPet == projectile.getShooter().getMyPet()) {
+                    MyPet shooterMyPet = projectile.getShooter().getMyPet();
+                    if (myPet == shooterMyPet) {
                         event.setCancelled(true);
                     }
-                    // Allow damage if both pets are dueling each other (bypasses PvP restrictions)
-                    // Must verify: shooter is in duel mode, target is in duel mode, AND shooter's target is the hit pet
-                    boolean inDuel = projectile.getShooter().getTargetPriority() == TargetPriority.Duel
-                            && myPet.getEntity().isPresent()
-                            && myPet.getEntity().get().getHandle().getTargetPriority() == TargetPriority.Duel
+                    // Allow damage if both pets are dueling each other (bypasses PvP restrictions).
+                    // Read the Behavior skill mode like the EntityDeathEvent duel handler below does:
+                    // the targetPriority field is never populated (setMyPetTarget ignores its priority
+                    // argument), so checking getTargetPriority() == Duel here would always be false and
+                    // duel projectiles would always be canceled. Also require the shooter to actually
+                    // be targeting the pet it hit.
+                    boolean inDuel = shooterMyPet.getSkills().isActive(Behavior.class)
+                            && myPet.getSkills().isActive(Behavior.class)
+                            && shooterMyPet.getSkills().get(Behavior.class).getBehavior() == BehaviorMode.Duel
+                            && myPet.getSkills().get(Behavior.class).getBehavior() == BehaviorMode.Duel
                             && projectile.getShooter().getMyPetTarget() == craftMyPet;
                     if (!inDuel && !MyPetApi.getHookHelper().canHurt(projectile.getShooter().getOwner().getPlayer(), myPet.getOwner().getPlayer(), true)) {
                         event.setCancelled(true);

--- a/plugin/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
@@ -398,6 +398,11 @@ public class PlayerListener implements Listener {
         if (MyPetApi.getPlayerManager().isMyPetPlayer(event.getPlayer())) {
             final MyPetPlayer myPetPlayer = MyPetApi.getPlayerManager().getMyPetPlayer(event.getPlayer());
 
+            // Race condition: player may have disconnected between isMyPetPlayer and getMyPetPlayer
+            if (myPetPlayer == null) {
+                return;
+            }
+
             final WorldGroup fromGroup = WorldGroup.getGroupByWorld(event.getFrom().getName());
 
             final MyPet myPet = myPetPlayer.hasMyPet() ? myPetPlayer.getMyPet() : null;

--- a/plugin/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
@@ -316,7 +316,7 @@ public class PlayerListener implements Listener {
                 CraftMyPetProjectile projectile = (CraftMyPetProjectile) event.getDamager();
                 if (MyPetApi.getPlayerManager().isMyPetPlayer(victim)) {
                     MyPetPlayer myPetPlayerDamagee = MyPetApi.getPlayerManager().getMyPetPlayer(victim);
-                    if (myPetPlayerDamagee.hasMyPet()) {
+                    if (myPetPlayerDamagee != null && myPetPlayerDamagee.hasMyPet()) {
                         if (projectile != null && projectile.getMyPetProjectile().getShooter() != null) {
                             if (myPetPlayerDamagee.getMyPet() == projectile.getMyPetProjectile().getShooter().getMyPet()) {
                                 event.setCancelled(true);
@@ -350,7 +350,7 @@ public class PlayerListener implements Listener {
                     return;
                 }
                 MyPetPlayer myPetPlayerDamagee = MyPetApi.getPlayerManager().getMyPetPlayer(victim);
-                if (myPetPlayerDamagee.hasMyPet()) {
+                if (myPetPlayerDamagee != null && myPetPlayerDamagee.hasMyPet()) {
                     MyPet myPet = myPetPlayerDamagee.getMyPet();
                     if (myPet.getSkills().has(ShieldImpl.class)) {
                         ShieldImpl shield = myPet.getSkills().get(ShieldImpl.class);

--- a/plugin/src/main/java/de/Keyle/MyPet/repository/types/MySqlRepository.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/repository/types/MySqlRepository.java
@@ -102,51 +102,54 @@ public class MySqlRepository implements Repository {
         dataSource.addDataSourceProperty("cachePrepStmts", true);
         dataSource.setLeakDetectionThreshold(10000);
 
+        // Read the schema version, then release the connection *before* running any
+        // migrations. The migration methods each borrow their own connection, so holding
+        // this one open across the whole ALTER TABLE chain only pinned it idle and could
+        // trip HikariCP's 10s leak detector on slow databases (MYPET-DMY).
+        int oldVersion;
         try (Connection connection = dataSource.getConnection();
              PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + Configuration.Repository.MySQL.PREFIX + "info;");
              ResultSet resultSet = statement.executeQuery()) {
 
             if (resultSet.next()) {
-                updateStructure(resultSet);
-                updateInfo();
+                oldVersion = resultSet.getInt("version");
             } else {
                 initStructure();
+                return;
             }
         } catch (SQLSyntaxErrorException e) {
             initStructure();
+            return;
         } catch (Exception e) {
             throw new RepositoryInitException(e);
         }
+
+        updateStructure(oldVersion);
+        updateInfo();
     }
 
-    private void updateStructure(ResultSet resultSet) {
-        try {
-            int oldVersion = resultSet.getInt("version");
+    private void updateStructure(int oldVersion) {
+        if (oldVersion < version) {
+            MyPetApi.getLogger().info("[MySQL] Updating database from v" + oldVersion + " to v" + version + ".");
 
-            if (oldVersion < version) {
-                MyPetApi.getLogger().info("[MySQL] Updating database from v" + oldVersion + " to v" + version + ".");
-
-                switch (oldVersion) {
-                    case 1:
-                        updateToV2();
-                    case 2:
-                        updateToV3();
-                    case 3:
-                        updateToV4();
-                    case 4:
-                        updateToV5();
-                    case 5:
-                        updateToV6();
-                    case 6:
-                    case 7:
-                        updateToV8();
-                    case 8:
-                    case 9:
-                        updateToV10();
-                }
+            switch (oldVersion) {
+                case 1:
+                    updateToV2();
+                case 2:
+                    updateToV3();
+                case 3:
+                    updateToV4();
+                case 4:
+                    updateToV5();
+                case 5:
+                    updateToV6();
+                case 6:
+                case 7:
+                    updateToV8();
+                case 8:
+                case 9:
+                    updateToV10();
             }
-        } catch (SQLException e) {
-            e.printStackTrace();
         }
     }
 

--- a/plugin/src/main/java/de/Keyle/MyPet/repository/types/SqLiteRepository.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/repository/types/SqLiteRepository.java
@@ -111,7 +111,12 @@ public class SqLiteRepository implements Repository {
                 initStructure();
             }
             resultSet.close();
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
+            // LinkageError (e.g. UnsatisfiedLinkError) is thrown when the server-provided
+            // sqlite-jdbc native library can't be linked — typically a version conflict with
+            // another plugin's org.sqlite on the shared classpath. It's an Error, not an
+            // Exception, so without this it would escape onEnable uncaught instead of routing
+            // into MyPet's intended "repository unavailable -> disable cleanly" path.
             e.printStackTrace();
             throw new RepositoryInitException(e);
         }

--- a/plugin/src/main/java/de/Keyle/MyPet/util/ConfigurationLoader.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/util/ConfigurationLoader.java
@@ -645,7 +645,7 @@ public class ConfigurationLoader {
                 List<String> foodList = config.getStringList("MyPet.Pets." + petType.name() + ".Food");
                 for (String foodString : foodList) {
                     ConfigItem ci = ConfigItem.createConfigItem(foodString);
-                    if (ci.getItem() != null && ci.getItem().getType() != Material.AIR) {
+                    if (ci != null && ci.getItem() != null && ci.getItem().getType() != Material.AIR) {
                         MyPetApi.getMyPetInfo().addFood(petType, ci);
                     }
                 }

--- a/plugin/src/main/java/de/Keyle/MyPet/util/hooks/MobStackerBHook.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/util/hooks/MobStackerBHook.java
@@ -36,7 +36,7 @@ public class MobStackerBHook implements LeashEntityHook {
 
     @Override
     public boolean onEnable() {
-        plugin = (MobStacker) MyPetApi.getPluginHookManager().getPluginInstance("StackMob").get();
+        plugin = MyPetApi.getPluginHookManager().getPluginInstance(MobStacker.class).get();
         Bukkit.getPluginManager().registerEvents(this, MyPetApi.getPlugin());
         return true;
     }

--- a/plugin/src/main/java/de/Keyle/MyPet/util/hooks/ProtocolLibHook.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/util/hooks/ProtocolLibHook.java
@@ -193,6 +193,9 @@ public class ProtocolLibHook implements PluginHook {
     }
 
     private void registerEnderDragonRotationFix19() {
+        // Cache version check result — it never changes at runtime
+        final boolean isAtLeast1_17 = MyPetApi.getCompatUtil().compareWithMinecraftVersion("1.17") >= 0;
+
         ProtocolLibrary.getProtocolManager().addPacketListener(
                 new PacketAdapter(MyPetApi.getPlugin(), getFixedPackets()) {
                     @Override
@@ -205,14 +208,14 @@ public class ProtocolLibHook implements PluginHook {
                         int id = packet.getIntegers().read(0);
 
                         Entity entity = null;
-                        if(MyPetApi.getCompatUtil().compareWithMinecraftVersion("1.17") < 0) {
+                        if (!isAtLeast1_17) {
                             try {
                                entity = packet.getEntityModifier(event).readSafely(0);
                             } catch (RuntimeException ignored) {
                             }
                         }
                         if (entity == null) {
-                            if(MyPetApi.getCompatUtil().compareWithMinecraftVersion("1.17") >= 0) { //1.17+ does not like async
+                            if (isAtLeast1_17) {
                                 try {
                                     entity = ensureMainThread(() -> MyPetApi.getPlatformHelper().getEntity(id, event.getPlayer().getWorld()));
                                 } catch (TimeoutException e) {

--- a/plugin/src/main/java/de/Keyle/MyPet/util/hooks/ProtocolLibHook.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/util/hooks/ProtocolLibHook.java
@@ -246,7 +246,11 @@ public class ProtocolLibHook implements PluginHook {
 
                         PacketContainer packet = event.getPacket();
 
-                        final Entity entity = packet.getEntityModifier(event).readSafely(0);
+                        Entity entity = null;
+                        try {
+                            entity = packet.getEntityModifier(event).readSafely(0);
+                        } catch (RuntimeException ignored) {
+                        }
 
                         if (entity instanceof MyPetBukkitEntity && ((MyPetBukkitEntity) entity).getPetType() == MyPetType.EnderDragon) {
 

--- a/plugin/src/main/java/de/Keyle/MyPet/util/hooks/WorldGuardHook.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/util/hooks/WorldGuardHook.java
@@ -96,7 +96,15 @@ public class WorldGuardHook implements PlayerVersusPlayerHook, PlayerVersusEntit
 
     public WorldGuardHook() {
         if (MyPetApi.getPluginHookManager().getConfig().getConfig().getBoolean("WorldGuard.Enabled")) {
-            if (ReflectionUtil.getMethod(com.sk89q.worldedit.util.Location.class, "toVector") == null) {
+            try {
+                if (ReflectionUtil.getMethod(com.sk89q.worldedit.util.Location.class, "toVector") == null) {
+                    return;
+                }
+            } catch (Throwable e) {
+                // Some server builds bundle a bytecode rewriter (e.g. Paper's Commodore) whose ASM
+                // version can't parse WorldEdit/WorldGuard classes compiled for a newer Java release,
+                // throwing here on first class-load instead of a normal ClassNotFoundException.
+                MyPetApi.getLogger().warning("Failed to inspect WorldEdit/WorldGuard classes - disabling the WorldGuard hook: " + e);
                 return;
             }
 

--- a/plugin/src/main/java/de/Keyle/MyPet/util/sentry/SentryErrorReporter.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/util/sentry/SentryErrorReporter.java
@@ -280,7 +280,9 @@ public class SentryErrorReporter implements ErrorReporter {
             }
             if (current instanceof java.sql.SQLException) {
                 String message = current.getMessage();
-                if (message != null && message.contains("Access denied")) {
+                if (message != null && (
+                        message.contains("Access denied") ||
+                        message.contains("is not allowed to connect"))) {
                     return true;
                 }
             }

--- a/plugin/src/main/java/de/Keyle/MyPet/util/sentry/SentryErrorReporter.java
+++ b/plugin/src/main/java/de/Keyle/MyPet/util/sentry/SentryErrorReporter.java
@@ -61,9 +61,17 @@ public class SentryErrorReporter implements ErrorReporter {
             return;
         }
 
+        // The DSN is injected at build time from a CI-only secret (see build.gradle.kts) rather than
+        // hardcoded, so forks that build via our release/snapshot workflows - but don't have our
+        // private SENTRY_DSN secret - get an empty DSN here and never report errors to our project.
+        String dsn = MyPetVersion.getSentryDsn();
+        if (dsn == null || dsn.isEmpty()) {
+            return;
+        }
+
         // Initialize Sentry with modern 8.0.0+ API
         Sentry.init(options -> {
-            options.setDsn("https://14aec086f95d4fbe8a378638c80b68fa@o221805.ingest.us.sentry.io/1368849");
+            options.setDsn(dsn);
             options.setSendDefaultPii(true);
             options.setTracesSampleRate(1.0);
             options.setDebug(false);


### PR DESCRIPTION
- Cache compareWithMinecraftVersion("1.17") result at listener registration instead of calling it on every outbound packet
- Simplify CompatUtil cache key to just the version string (minecraftVersion is constant at runtime)
- Check cache before regex validation to avoid unnecessary Matcher allocation on repeated calls