### PR TITLE
Fix goat pets destroying stacked buckets when milked

### DIFF
--- a/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGoat.java
+++ b/nms/v1_17_R1/src/main/java/de/Keyle/MyPet/compat/v1_17_R1/entity/types/EntityMyGoat.java
@@ -77,8 +77,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyGoat.java
+++ b/nms/v1_18_R2/src/main/java/de/Keyle/MyPet/compat/v1_18_R2/entity/types/EntityMyGoat.java
@@ -77,8 +77,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyGoat.java
+++ b/nms/v1_19_R1/src/main/java/de/Keyle/MyPet/compat/v1_19_R1/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyGoat.java
+++ b/nms/v1_19_R2/src/main/java/de/Keyle/MyPet/compat/v1_19_R2/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyGoat.java
+++ b/nms/v1_19_R3/src/main/java/de/Keyle/MyPet/compat/v1_19_R3/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyGoat.java
+++ b/nms/v1_20_R1/src/main/java/de/Keyle/MyPet/compat/v1_20_R1/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyGoat.java
+++ b/nms/v1_20_R2/src/main/java/de/Keyle/MyPet/compat/v1_20_R2/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyGoat.java
+++ b/nms/v1_20_R3/src/main/java/de/Keyle/MyPet/compat/v1_20_R3/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyGoat.java
+++ b/nms/v1_20_R4/src/main/java/de/Keyle/MyPet/compat/v1_20_R4/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyGoat.java
+++ b/nms/v1_21_R1/src/main/java/de/Keyle/MyPet/compat/v1_21_R1/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyGoat.java
+++ b/nms/v1_21_R2/src/main/java/de/Keyle/MyPet/compat/v1_21_R2/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyGoat.java
+++ b/nms/v1_21_R3/src/main/java/de/Keyle/MyPet/compat/v1_21_R3/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().selected, milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyGoat.java
+++ b/nms/v1_21_R4/src/main/java/de/Keyle/MyPet/compat/v1_21_R4/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyGoat.java
+++ b/nms/v1_21_R5/src/main/java/de/Keyle/MyPet/compat/v1_21_R5/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyGoat.java
+++ b/nms/v1_21_R6/src/main/java/de/Keyle/MyPet/compat/v1_21_R6/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyGoat.java
+++ b/nms/v1_21_R7/src/main/java/de/Keyle/MyPet/compat/v1_21_R7/entity/types/EntityMyGoat.java
@@ -80,8 +80,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyGoat.java
+++ b/nms/v26_1_R1/src/main/java/de/Keyle/MyPet/compat/v26_1_R1/entity/types/EntityMyGoat.java
@@ -81,8 +81,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {

--- a/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyGoat.java
+++ b/nms/v26_2_R1/src/main/java/de/Keyle/MyPet/compat/v26_2_R1/entity/types/EntityMyGoat.java
@@ -81,8 +81,14 @@ public class EntityMyGoat extends EntityMyPet {
         if (getOwner().equals(entityhuman) && itemStack != null && canUseItem()) {
             if (itemStack.getItem() == Items.BUCKET && Configuration.MyPet.Goat.CAN_GIVE_MILK) {
                 ItemStack milkBucket = new ItemStack(Items.MILK_BUCKET);
-
-                entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                itemStack.shrink(1);
+                if (itemStack.getCount() <= 0) {
+                    entityhuman.getInventory().setItem(entityhuman.getInventory().getSelectedSlot(), milkBucket);
+                } else {
+                    if (!entityhuman.getInventory().add(milkBucket)) {
+                        entityhuman.drop(milkBucket, true);
+                    }
+                }
                 return InteractionResult.CONSUME;
             } else if (Configuration.MyPet.Goat.GROW_UP_ITEM.compare(itemStack) && getMyPet().isBaby() && getOwner().getPlayer().isSneaking()) {
                 if (itemStack != ItemStack.EMPTY && !entityhuman.getAbilities().instabuild) {


### PR DESCRIPTION
## Problem

Milking a **goat pet** while holding a stack of empty buckets replaces the entire held hotbar slot with a single milk bucket, destroying every other bucket in the stack.

This is the exact same bug that was reported for cows in #1553 and fixed in commit 34cbe4e ("Fix Cows stealing buckets", ~build B1695) — but that fix was only applied to `EntityMyCow` and never ported to `EntityMyGoat`. The goat has shipped with the old `inventory.setItem(selectedSlot, milkBucket)` implementation since it was added in the 1.17 module.

Because the bug is a pure server-side inventory mutation, it reproduces identically on Java and on Bedrock (Geyser/Floodgate) — it is not a client-prediction/Geyser desync.

### Reproduce
1. Have a goat pet with `MyPet.Pets.Goat.CanGiveMilk: true` (default).
2. Hold a stack of ≥2 empty buckets.
3. Right-click the goat pet.
4. → You receive 1 milk bucket and the rest of the bucket stack is gone.

## Fix

Align `EntityMyGoat#handlePlayerInteraction` with the already-fixed `EntityMyCow`:

- `itemStack.shrink(1)` — consume only one empty bucket
- if the stack is now empty, replace the selected slot with the milk bucket
- otherwise add the milk bucket to the inventory, dropping it if the inventory is full

The `GROW_UP_ITEM` branch already does a proper count check and is left untouched.

## Scope

All 18 NMS modules that contain `EntityMyGoat` (`v1_17_R1` … `v1_21_R7`, `v26_1_R1`, `v26_2_R1`). The change in each file is identical apart from the pre-existing `selected` vs `getSelectedSlot()` accessor.

## Notes

- No behavioural change for the single-bucket case (still replaces the slot).
- I could not run the NMS build locally (it needs the private Spigot mirror credentials), so CI compilation is the first real check. The change is a line-for-line port of the production `EntityMyCow` logic using only symbols already referenced by the sibling class in each module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
